### PR TITLE
Updated server artifact name

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -38,7 +38,7 @@ export async function activate(context: ExtensionContext) {
     'sonatype:releases',
     '-J',
     toolsJar,
-    'org.scalameta:language-server_2.12:0.1-SNAPSHOT',
+    'org.scalameta:metaserver_2.12:0.1-SNAPSHOT',
     '-M',
     'scala.meta.languageserver.Main'
   ];


### PR DESCRIPTION
After #22 server subproject is renamed to metaserver and published with this name. So I changed it in the client code as well.