### PR TITLE
Removed warning about missing Scalafix config

### DIFF
--- a/metaserver/src/main/scala/scala/meta/languageserver/Linter.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Linter.scala
@@ -98,11 +98,6 @@ class Linter(
   private def withConfig[T](f: m.Input => Seq[T]): Seq[T] =
     configFile match {
       case None =>
-        // would be good to debounce this message, see Observable[T].debounce
-        connection.showMessage(
-          MessageType.Warning,
-          s"Missing ${cwd.resolve(".scalafix.conf")}"
-        )
         Nil
       case Some(configInput) =>
         f(configInput)


### PR DESCRIPTION
As suggested in https://github.com/scalameta/language-server/issues/16#issuecomment-343088536