### PR TITLE
Moved server logs to target/

### DIFF
--- a/metaserver/src/main/scala/scala/meta/languageserver/Main.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Main.scala
@@ -11,8 +11,8 @@ object Main extends LazyLogging {
   def main(args: Array[String]): Unit = {
     // FIXME(gabro): this is vscode specific (at least the name)
     val workspace = System.getProperty("vscode.workspace")
-    val out = new PrintStream(new FileOutputStream(s"$workspace/pc.stdout.log"))
-    val err = new PrintStream(new FileOutputStream(s"$workspace/pc.stdout.log"))
+    val out = new PrintStream(new FileOutputStream(s"$workspace/target/pc.stdout.log"))
+    val err = new PrintStream(new FileOutputStream(s"$workspace/target/pc.stderr.log"))
     val cwd = AbsolutePath(workspace)
     val server =
       new ScalametaLanguageServer(cwd, System.in, System.out, out)

--- a/metaserver/src/main/scala/scala/meta/languageserver/Main.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Main.scala
@@ -11,8 +11,9 @@ object Main extends LazyLogging {
   def main(args: Array[String]): Unit = {
     // FIXME(gabro): this is vscode specific (at least the name)
     val workspace = System.getProperty("vscode.workspace")
-    val out = new PrintStream(new FileOutputStream(s"$workspace/target/pc.stdout.log"))
-    val err = new PrintStream(new FileOutputStream(s"$workspace/target/pc.stdout.log"))
+    val logPath = s"${workspace}/target/metaserver.log"
+    val out = new PrintStream(new FileOutputStream(logPath))
+    val err = new PrintStream(new FileOutputStream(logPath))
     val cwd = AbsolutePath(workspace)
     val server =
       new ScalametaLanguageServer(cwd, System.in, System.out, out)

--- a/metaserver/src/main/scala/scala/meta/languageserver/Main.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Main.scala
@@ -12,7 +12,7 @@ object Main extends LazyLogging {
     // FIXME(gabro): this is vscode specific (at least the name)
     val workspace = System.getProperty("vscode.workspace")
     val out = new PrintStream(new FileOutputStream(s"$workspace/target/pc.stdout.log"))
-    val err = new PrintStream(new FileOutputStream(s"$workspace/target/pc.stderr.log"))
+    val err = new PrintStream(new FileOutputStream(s"$workspace/target/pc.stdout.log"))
     val cwd = AbsolutePath(workspace)
     val server =
       new ScalametaLanguageServer(cwd, System.in, System.out, out)


### PR DESCRIPTION
Having a log file the in root of every project is not very Git-friendly 😄 (sure I added it to the global gitignore, but still). So I moved it to `target/`. This is also convenient because you can reset logs when running `clean` in sbt.

I also changed stderr log file, but probably you want to have them together.  Also, what does `pc` in the name stand for?