### PR TITLE
Fixed empty tooltips on hover

### DIFF
--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
@@ -250,14 +250,14 @@ class ScalametaLanguageServer(
   ): Hover = {
     val path = Uri.toPath(td.uri).get.toRelative(cwd)
     symbol.hoverInformation(path, position.line, position.character) match {
-      case None => Hover(Nil, None)
-      case Some((pos, denotation)) =>
+      case Some((pos, denotation)) if denotation.signature.nonEmpty =>
         Hover(
           contents = List(
             RawMarkedString(language = "scala", value = denotation.signature)
           ),
           range = Some(pos.toRange)
         )
+      case _ => Hover(Nil, None)
     }
   }
 


### PR DESCRIPTION
Fixes #27.

If the denotation signature is empty, send an empty list of marked strings, not a list with an empty string. See https://github.com/scalameta/language-server/issues/27#issuecomment-343493411 for the explanation.
