### PR TITLE
Switch to lsp4j

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,19 +6,6 @@ inThisBuild(
   )
 )
 
-lazy val languageserver = project
-  .settings(
-    resolvers += "dhpcs at bintray" at "https://dl.bintray.com/dhpcs/maven",
-    libraryDependencies ++= Seq(
-      "com.dhpcs" %% "scala-json-rpc" % "2.0.1",
-      "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2",
-      "org.slf4j" % "slf4j-api" % "1.7.21",
-      "ch.qos.logback" % "logback-classic" % "1.1.7",
-      "org.codehaus.groovy" % "groovy" % "2.4.0",
-      "org.scalatest" %% "scalatest" % "3.0.1" % "test"
-    )
-  )
-
 lazy val metaserver = project
   .settings(
     resolvers += "dhpcs at bintray" at "https://dl.bintray.com/dhpcs/maven",
@@ -27,8 +14,10 @@ lazy val metaserver = project
       "io.get-coursier" %% "coursier" % coursier.util.Properties.version,
       "io.get-coursier" %% "coursier-cache" % coursier.util.Properties.version,
       "ch.epfl.scala" % "scalafix-cli" % "0.5.3" cross CrossVersion.full,
-      "com.geirsson" %% "scalafmt-core" % "1.3.0"
+      "com.geirsson" %% "scalafmt-core" % "1.3.0",
+      "org.eclipse.lsp4j" % "org.eclipse.lsp4j" % "0.3.0",
+      "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2",
+      "org.slf4j" % "slf4j-api" % "1.7.21",
+      "ch.qos.logback" % "logback-classic" % "1.1.7"
     )
   )
-  .dependsOn(languageserver)
-  .aggregate(languageserver)

--- a/metaserver/src/main/java/metaserver/ScalametaTextDocumentService.java
+++ b/metaserver/src/main/java/metaserver/ScalametaTextDocumentService.java
@@ -1,0 +1,125 @@
+package metaserver;
+
+import org.eclipse.lsp4j.*;
+import org.eclipse.lsp4j.services.TextDocumentService;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.List;
+
+import scala.meta.languageserver.ScalametaLanguageServer;
+
+public class ScalametaTextDocumentService implements TextDocumentService {
+
+  private ScalametaLanguageServer server;
+
+  public ScalametaTextDocumentService(ScalametaLanguageServer server) {
+    this.server = server;
+  }
+
+  @Override
+  public CompletableFuture<Either<List<CompletionItem>, CompletionList>> completion(TextDocumentPositionParams position) {
+     return server.completion(position);
+  }
+
+  @Override
+  public CompletableFuture<CompletionItem> resolveCompletionItem(CompletionItem unresolved) {
+    return server.resolveCompletionItem(unresolved);
+  }
+
+  @Override
+  public CompletableFuture<Hover> hover(TextDocumentPositionParams position) {
+    return server.hover(position);
+  }
+
+  @Override
+  public CompletableFuture<SignatureHelp> signatureHelp(TextDocumentPositionParams position) {
+    return server.signatureHelp(position);
+  }
+
+  @Override
+  public CompletableFuture<List<? extends Location>> definition(TextDocumentPositionParams position) {
+    return server.definition(position);
+  }
+
+  @Override
+  public CompletableFuture<List<? extends Location>> references(ReferenceParams params) {
+    return server.references(params);
+  }
+
+  @Override
+  public CompletableFuture<List<? extends DocumentHighlight>> documentHighlight(TextDocumentPositionParams position) {
+    return server.documentHighlight(position);
+  }
+
+  @Override
+  public CompletableFuture<List<? extends SymbolInformation>> documentSymbol(DocumentSymbolParams params) {
+    return server.documentSymbol(params);
+  }
+
+  @Override
+  public CompletableFuture<List<? extends Command>> codeAction(CodeActionParams params) {
+    return server.codeAction(params);
+  }
+
+  @Override
+  public CompletableFuture<List<? extends CodeLens>> codeLens(CodeLensParams params) {
+    return server.codeLens(params);
+  }
+
+  @Override
+  public CompletableFuture<CodeLens> resolveCodeLens(CodeLens unresolved) {
+    return server.resolveCodeLens(unresolved);
+  }
+
+  @Override
+  public CompletableFuture<List<? extends TextEdit>> formatting(DocumentFormattingParams params) {
+    return server.formatting(params);
+  }
+
+  @Override
+  public CompletableFuture<List<? extends TextEdit>> rangeFormatting(DocumentRangeFormattingParams params) {
+    return server.rangeFormatting(params);
+  }
+
+  @Override
+  public CompletableFuture<List<? extends TextEdit>> onTypeFormatting(DocumentOnTypeFormattingParams params) {
+    return server.onTypeFormatting(params);
+  }
+
+  @Override
+  public CompletableFuture<List<DocumentLink>> documentLink(DocumentLinkParams params) {
+    return server.documentLink(params);
+  }
+
+  @Override
+  public CompletableFuture<DocumentLink> documentLinkResolve(DocumentLink params) {
+    return server.documentLinkResolve(params);
+  }
+
+  @Override
+  public CompletableFuture<WorkspaceEdit> rename(RenameParams params) {
+    return server.rename(params);
+  }
+
+  @Override
+  public void didOpen(DidOpenTextDocumentParams params) {
+    server.didOpen(params);
+  }
+
+  @Override
+  public void didChange(DidChangeTextDocumentParams params) {
+    server.didChange(params);
+  }
+
+  @Override
+  public void didClose(DidCloseTextDocumentParams params) {
+    server.didClose(params);
+  }
+
+  @Override
+  public void didSave(DidSaveTextDocumentParams params) {
+    server.didSave(params);
+  }
+
+}

--- a/metaserver/src/main/java/metaserver/ScalametaWorkspaceService.java
+++ b/metaserver/src/main/java/metaserver/ScalametaWorkspaceService.java
@@ -1,0 +1,31 @@
+package metaserver;
+
+import org.eclipse.lsp4j.services.WorkspaceService;
+import org.eclipse.lsp4j.*;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.List;
+
+import scala.meta.languageserver.ScalametaLanguageServer;
+
+public class ScalametaWorkspaceService implements WorkspaceService {
+
+  private ScalametaLanguageServer server;
+
+  public ScalametaWorkspaceService(ScalametaLanguageServer server) {
+    this.server = server;
+  }
+
+  @Override public void didChangeWatchedFiles(DidChangeWatchedFilesParams params) {
+    server.didChangeWatchedFiles(params);
+  }
+
+  @Override public void didChangeConfiguration(DidChangeConfigurationParams params) {
+    server.didChangeConfiguration(params);
+  }
+
+  @Override public CompletableFuture<List<? extends SymbolInformation>> symbol(WorkspaceSymbolParams params) {
+    return server.symbol(params);
+  }
+
+}

--- a/metaserver/src/main/scala/scala/meta/languageserver/Compiler.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Compiler.scala
@@ -9,10 +9,12 @@ import scala.tools.nsc.Settings
 import scala.tools.nsc.interactive.{Global, Response}
 import scala.tools.nsc.reporters.StoreReporter
 import com.typesafe.scalalogging.LazyLogging
-import langserver.core.Connection
-import langserver.messages.MessageType
 import monix.reactive.Observable
 import org.langmeta.io.AbsolutePath
+
+import org.eclipse.lsp4j.services.LanguageClient
+import org.eclipse.lsp4j.MessageParams
+import org.eclipse.lsp4j.MessageType
 
 case class CompilerConfig(
     sources: List[AbsolutePath],
@@ -41,7 +43,7 @@ object CompilerConfig {
 }
 class Compiler(
     config: Observable[AbsolutePath],
-    connection: Connection,
+    client: LanguageClient,
     buffers: Buffers
 )(implicit cwd: AbsolutePath)
     extends LazyLogging {
@@ -106,11 +108,11 @@ class Compiler(
     }
   }
   private def noCompletions: List[(String, String)] = {
-    connection.showMessage(
+    client.showMessage(new MessageParams(
       MessageType.Warning,
       "Run project/config:scalametaEnableCompletions to setup completion for this " +
         "config.in(project) or *:scalametaEnableCompletions for all projects/configurations"
-    )
+    ))
     Nil
   }
   private def lineColumnToOffset(

--- a/metaserver/src/main/scala/scala/meta/languageserver/Main.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Main.scala
@@ -7,6 +7,8 @@ import com.typesafe.scalalogging.LazyLogging
 import org.langmeta.io.AbsolutePath
 import monix.execution.Scheduler.Implicits.global // TODO(olafur) may want to customize
 
+import org.eclipse.lsp4j.launch.LSPLauncher
+
 object Main extends LazyLogging {
   def main(args: Array[String]): Unit = {
     // FIXME(gabro): this is vscode specific (at least the name)
@@ -15,8 +17,6 @@ object Main extends LazyLogging {
     val out = new PrintStream(new FileOutputStream(logPath))
     val err = new PrintStream(new FileOutputStream(logPath))
     val cwd = AbsolutePath(workspace)
-    val server =
-      new ScalametaLanguageServer(cwd, System.in, System.out, out)
 
     // route System.out somewhere else. Any output not from the server (e.g. logging)
     // messes up with the client, since stdout is used for the language server protocol
@@ -26,7 +26,11 @@ object Main extends LazyLogging {
       System.setErr(err)
       logger.info(s"Starting server in $workspace")
       logger.info(s"Classpath: ${Properties.javaClassPath}")
-      server.start()
+      val server = new ScalametaLanguageServer(cwd, out)
+      val launcher = LSPLauncher.createServerLauncher(server, System.in, out)
+      val client = launcher.getRemoteProxy()
+      server.connect(client)
+      launcher.startListening()
     } finally {
       System.setOut(origOut)
     }

--- a/metaserver/src/main/scala/scala/meta/languageserver/Main.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Main.scala
@@ -27,7 +27,7 @@ object Main extends LazyLogging {
       logger.info(s"Starting server in $workspace")
       logger.info(s"Classpath: ${Properties.javaClassPath}")
       val server = new ScalametaLanguageServer(cwd, out)
-      val launcher = LSPLauncher.createServerLauncher(server, System.in, out)
+      val launcher = LSPLauncher.createServerLauncher(server, System.in, origOut)
       val client = launcher.getRemoteProxy()
       server.connect(client)
       launcher.startListening()

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaEnrichments.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaEnrichments.scala
@@ -1,13 +1,15 @@
 package scala.meta.languageserver
 
 import scala.{meta => m}
-import langserver.types.SymbolKind
-import langserver.{types => l}
+
+import org.eclipse.lsp4j.Range
+import org.eclipse.lsp4j.Position
+import org.eclipse.lsp4j.Location
+import org.eclipse.lsp4j.SymbolKind
 
 // Extension methods for convenient reuse of data conversions between
 // scala.meta._ and language.types._
 object ScalametaEnrichments {
-  type SymbolKind = Int
 
   implicit class XtensionDenotationLSP(val denotation: m.Denotation)
       extends AnyVal {
@@ -31,16 +33,16 @@ object ScalametaEnrichments {
   }
   implicit class XtensionAbsolutePathLSP(val path: m.AbsolutePath)
       extends AnyVal {
-    def toLocation(pos: m.Position): l.Location =
-      l.Location(path.toLanguageServerUri, pos.toRange)
+    def toLocation(pos: m.Position): Location =
+      new Location(path.toLanguageServerUri, pos.toRange)
     def toLanguageServerUri: String = "file:" + path.toString()
   }
   implicit class XtensionPositionRangeLSP(val pos: m.Position) extends AnyVal {
     def location: String =
       s"${pos.input.syntax}:${pos.startLine}:${pos.startColumn}"
-    def toRange: l.Range = l.Range(
-      l.Position(line = pos.startLine, character = pos.startColumn),
-      l.Position(line = pos.endLine, character = pos.endColumn)
+    def toRange: Range = new Range(
+      new Position(pos.startLine, pos.startColumn),
+      new Position(pos.endLine, pos.endColumn)
     )
   }
 }

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
@@ -260,6 +260,7 @@ class ScalametaLanguageServer(
   }
 
   // Unimplemented features
+  override def initialized(params: InitializedParams) = ???
   def codeAction(params: CodeActionParams): CompletableFuture[JList[_ <: Command]] = ???
   def codeLens(params: CodeLensParams): CompletableFuture[JList[_ <: CodeLens]] = ???
   def didClose(params: DidCloseTextDocumentParams) = ???

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
@@ -12,19 +12,6 @@ import java.nio.file.attribute.BasicFileAttributes
 import scala.collection.mutable.ListBuffer
 import scala.meta.languageserver.ScalametaEnrichments._
 import scala.util.control.NonFatal
-import langserver.core.LanguageServer
-import langserver.messages.ClientCapabilities
-import langserver.messages.CompletionList
-import langserver.messages.CompletionOptions
-import langserver.messages.DefinitionResult
-import langserver.messages.FileChangeType
-import langserver.messages.FileEvent
-import langserver.messages.MessageType
-import langserver.messages.ResultResponse
-import langserver.messages.ServerCapabilities
-import langserver.messages.ShutdownResult
-import langserver.messages.Hover
-import langserver.types._
 import monix.execution.Cancelable
 import monix.execution.Scheduler
 import monix.reactive.MulticastStrategy
@@ -36,33 +23,50 @@ import org.langmeta.io.AbsolutePath
 import org.langmeta.semanticdb.Database
 import org.langmeta.semanticdb.Denotation
 
+import org.eclipse.lsp4j._
+import org.eclipse.lsp4j.services._
+import org.eclipse.lsp4j.jsonrpc.messages.{Either => JEither}
+
+import java.util.concurrent.CompletableFuture
+import java.util.{ List => JList }
+import scala.collection.JavaConverters._
+
+import com.typesafe.scalalogging.LazyLogging
+
 class ScalametaLanguageServer(
     cwd: AbsolutePath,
-    lspIn: InputStream,
-    lspOut: OutputStream,
     stdout: PrintStream
-)(implicit s: Scheduler)
-    extends LanguageServer(lspIn, lspOut) {
+)(implicit s: Scheduler) extends LanguageServer with LanguageClientAware with TextDocumentService with WorkspaceService with LazyLogging {
+
   implicit val workspacePath: AbsolutePath = cwd
-  val (semanticdbSubscriber, semanticdbPublisher) =
-    ScalametaLanguageServer.semanticdbStream
+
+  private var client: LanguageClient = _
+
+  val (semanticdbSubscriber, semanticdbPublisher) = ScalametaLanguageServer.semanticdbStream
+
   val (compilerConfigSubscriber, compilerConfigPublisher) =
     Observable.multicast[AbsolutePath](
       MulticastStrategy.Publish,
       OverflowStrategy.ClearBuffer(2)
     )
+
   def onError(e: Throwable): Unit = {
     logger.error(e.getMessage, e)
   }
+
   val buffers: Buffers = Buffers()
+
   val symbol: SymbolIndexer =
-    SymbolIndexer(semanticdbPublisher, logger, connection, buffers)
+    SymbolIndexer(semanticdbPublisher, logger, client, buffers)
+
   val scalafix: Linter =
-    new Linter(cwd, stdout, connection, semanticdbPublisher.doOnError(onError))
+    new Linter(cwd, stdout, client, semanticdbPublisher.doOnError(onError))
+
   val scalafmt: Formatter = Formatter.classloadScalafmt("1.3.0", stdout)
+
   val compiler = new Compiler(
     compilerConfigPublisher.doOnError(onError),
-    connection,
+    client,
     buffers
   )
 
@@ -92,34 +96,6 @@ class ScalametaLanguageServer(
     )
   }
 
-  override def initialize(
-      pid: Long,
-      rootPath: String,
-      capabilities: ClientCapabilities
-  ): ServerCapabilities = {
-    logger.info(s"Initialized with $cwd, $pid, $rootPath, $capabilities")
-    toCancel += scalafix.linter.subscribe()
-    toCancel += symbol.indexer.subscribe()
-    toCancel += compiler.onNewCompilerConfig.subscribe()
-    loadAllSemanticdbsInWorkspace()
-    ServerCapabilities(
-      completionProvider = Some(
-        CompletionOptions(
-          resolveProvider = true,
-          triggerCharacters = "." :: Nil
-        )
-      ),
-      definitionProvider = true,
-      documentSymbolProvider = true,
-      documentFormattingProvider = true,
-      hoverProvider = true
-    )
-  }
-
-  override def shutdown(): Unit = {
-    toCancel.foreach(_.cancel())
-  }
-
   private def onChangedFile(
       path: AbsolutePath
   )(fallback: AbsolutePath => Unit): Unit = {
@@ -134,14 +110,42 @@ class ScalametaLanguageServer(
     }
   }
 
-  override def onChangeWatchedFiles(changes: Seq[FileEvent]): Unit =
-    changes.foreach {
-      case FileEvent(
-          Uri(path),
-          FileChangeType.Created | FileChangeType.Changed
-          ) =>
-        onChangedFile(path) { _ =>
-          logger.warn(s"Unknown file extension for path $path")
+  override def connect(client: LanguageClient): Unit = {
+    this.client = client
+  }
+
+  override def initialize(params: InitializeParams): CompletableFuture[InitializeResult] = CompletableFuture.completedFuture {
+    logger.info(s"Initialized with $cwd, ${params.getProcessId}, ${params.getRootUri}, ${params.getCapabilities}")
+    toCancel += scalafix.linter.subscribe()
+    toCancel += symbol.indexer.subscribe()
+    toCancel += compiler.onNewCompilerConfig.subscribe()
+    loadAllSemanticdbsInWorkspace()
+
+    val capabilities = new ServerCapabilities
+    capabilities.setTextDocumentSync(TextDocumentSyncKind.Full)
+    capabilities.setDocumentFormattingProvider(true)
+    capabilities.setDocumentSymbolProvider(true)
+    capabilities.setHoverProvider(true)
+    capabilities.setDefinitionProvider(true)
+    capabilities.setCompletionProvider(new CompletionOptions(true, List(".").asJava))
+
+    new InitializeResult(capabilities)
+  }
+
+  override def exit(): Unit = {}
+
+  override def shutdown(): CompletableFuture[Object] = CompletableFuture.completedFuture {
+    toCancel.foreach(_.cancel())
+    new Object
+  }
+
+  override def didChangeWatchedFiles(params: DidChangeWatchedFilesParams): Unit =
+    params.getChanges.asScala.foreach {
+      case change: FileEvent if change.getType == FileChangeType.Created || change.getType == FileChangeType.Changed =>
+        Uri.toPath(change.getUri).foreach { path =>
+          onChangedFile(path) { _ =>
+            logger.warn(s"Unknown file extension for path $path")
+          }
         }
 
       case event =>
@@ -149,117 +153,125 @@ class ScalametaLanguageServer(
         ()
     }
 
-  override def documentFormattingRequest(
-      td: TextDocumentIdentifier,
-      options: FormattingOptions
-  ): List[TextEdit] = {
+  override def didOpen(params: DidOpenTextDocumentParams): Unit = {
+    val document = params.getTextDocument
+    Uri.toPath(document.getUri).foreach(p => buffers.changed(p, document.getText))
+  }
+
+  override def didChange(params: DidChangeTextDocumentParams): Unit = {
+    val document = params.getTextDocument
+    params.getContentChanges.asScala.foreach { c =>
+      Uri.toPath(document.getUri).foreach(p => buffers.changed(p, c.getText))
+    }
+  }
+
+  override def getTextDocumentService(): TextDocumentService = this
+  override def getWorkspaceService(): WorkspaceService = this
+
+  override def formatting(params: DocumentFormattingParams) = CompletableFuture.completedFuture {
+    val document = params.getTextDocument
     try {
-      val path = Uri.toPath(td.uri).get
+      val path = Uri.toPath(document.getUri).get
       val contents = buffers.read(path)
-      val fullDocumentRange = Range(
-        start = Position(0, 0),
-        end = Position(Int.MaxValue, Int.MaxValue)
+      val fullDocumentRange = new Range(
+        new Position(0, 0),
+        new Position(Int.MaxValue, Int.MaxValue)
       )
       val config = cwd.resolve(".scalafmt.conf")
       if (Files.isRegularFile(config.toNIO)) {
         val formattedContent =
           scalafmt.format(contents, config.toString(), path.toString())
-        List(TextEdit(fullDocumentRange, formattedContent))
+        List(new TextEdit(fullDocumentRange, formattedContent)).asJava
       } else {
-        connection.showMessage(MessageType.Info, s"Missing $config")
-        Nil
+        client.showMessage(new MessageParams(MessageType.Info, s"Missing $config"))
+        Nil.asJava
       }
     } catch {
       case NonFatal(e) =>
-        connection.showMessage(MessageType.Error, e.getMessage)
+        client.showMessage(new MessageParams(MessageType.Error, e.getMessage))
         logger.error(e.getMessage, e)
-        Nil
+        Nil.asJava
     }
   }
 
-  override def onOpenTextDocument(td: TextDocumentItem): Unit =
-    Uri.toPath(td.uri).foreach(p => buffers.changed(p, td.text))
-
-  override def onChangeTextDocument(
-      td: VersionedTextDocumentIdentifier,
-      changes: Seq[TextDocumentContentChangeEvent]
-  ): Unit = {
-    changes.foreach { c =>
-      Uri.toPath(td.uri).foreach(p => buffers.changed(p, c.text))
-    }
-  }
-
-  override def documentSymbols(
-      td: TextDocumentIdentifier
-  ): Seq[SymbolInformation] = {
-    val path = Uri.toPath(td.uri).get
+  override def documentSymbol(params: DocumentSymbolParams) = CompletableFuture.completedFuture {
+    val document = params.getTextDocument
+    val path = Uri.toPath(document.getUri).get
     symbol.documentSymbols(path.toRelative(cwd)).map {
       case (position, denotation @ Denotation(_, name, signature, _)) =>
         val location = path.toLocation(position)
         val kind = denotation.symbolKind
-        SymbolInformation(name, kind, location, Some(signature))
-    }
+        new SymbolInformation(name, kind, location, signature)
+    }.asJava
   }
 
-  override def gotoDefinitionRequest(
-      td: TextDocumentIdentifier,
-      position: Position
-  ): DefinitionResult = {
-    val path = Uri.toPath(td.uri).get.toRelative(cwd)
+  override def definition(params: TextDocumentPositionParams) = CompletableFuture.completedFuture {
+    val document = params.getTextDocument
+    val position = params.getPosition
+    val path = Uri.toPath(document.getUri).get.toRelative(cwd)
     symbol
-      .goToDefinition(path, position.line, position.character)
-      .fold(DefinitionResult(Nil)) { position =>
-        DefinitionResult(
-          cwd.resolve(position.input.syntax).toLocation(position) :: Nil
-        )
-      }
+      .goToDefinition(path, position.getLine, position.getCharacter)
+      .fold(List.empty[Location]) { position =>
+        cwd.resolve(position.input.syntax).toLocation(position) :: Nil
+      }.asJava
   }
 
-  override def onSaveTextDocument(td: TextDocumentIdentifier): Unit = {}
+  override def completion(params: TextDocumentPositionParams) = CompletableFuture.completedFuture {
+    val document = params.getTextDocument
+    val position = params.getPosition
 
-  override def completionRequest(
-      td: TextDocumentIdentifier,
-      position: Position
-  ): ResultResponse = {
     try {
       val completions = compiler.autocomplete(
-        Uri.toPath(td.uri).get,
-        position.line,
-        position.character
+        Uri.toPath(document.getUri).get,
+        position.getLine,
+        position.getCharacter
       )
-      CompletionList(
-        isIncomplete = false,
-        items = completions.map {
+      JEither.forRight(new CompletionList(
+        false,
+        completions.map {
           case (signature, name) =>
-            CompletionItem(
-              label = name,
-              detail = Some(signature)
-            )
-        }
-      )
+            val completionItem = new CompletionItem(name)
+            completionItem.setDetail(signature)
+            completionItem
+        }.asJava
+      ))
     } catch {
       case NonFatal(e) =>
         onError(e)
-        ShutdownResult(-1)
+        JEither.forRight(new CompletionList(Nil.asJava))
     }
   }
 
-  override def hoverRequest(
-      td: TextDocumentIdentifier,
-      position: Position
-  ): Hover = {
-    val path = Uri.toPath(td.uri).get
-    compiler.typeAt(path, position.line, position.character) match {
-      case None => Hover(Nil, None)
+  override def hover(params: TextDocumentPositionParams) = CompletableFuture.completedFuture {
+    val document = params.getTextDocument
+    val position = params.getPosition
+    val path = Uri.toPath(document.getUri).get
+    compiler.typeAt(path, position.getLine, position.getCharacter) match {
+      case None => new Hover(Nil.asJava)
       case Some(tpeName) =>
-        Hover(
-          contents = List(
-            RawMarkedString(language = "scala", value = tpeName)
-          ),
-          range = None
+        new Hover(
+          List(
+            JEither.forRight[String, MarkedString](new MarkedString("scala", tpeName))
+          ).asJava
         )
     }
   }
+
+  // Unimplemented features
+  override def codeAction(params: CodeActionParams) = ???
+  override def codeLens(params: CodeLensParams) = ???
+  override def didClose(params: DidCloseTextDocumentParams) = ???
+  override def didSave(params: DidSaveTextDocumentParams) = ???
+  override def documentHighlight(params: TextDocumentPositionParams) = ???
+  override def onTypeFormatting(params: DocumentOnTypeFormattingParams) = ???
+  override def rangeFormatting(params: DocumentRangeFormattingParams) = ???
+  override def references(params: ReferenceParams) = ???
+  override def rename(params: RenameParams) = ???
+  override def resolveCodeLens(params: CodeLens) = ???
+  override def resolveCompletionItem(params: CompletionItem) = ???
+  override def signatureHelp(params: TextDocumentPositionParams) = ???
+  override def didChangeConfiguration(params: DidChangeConfigurationParams) = ???
+  override def symbol(params: WorkspaceSymbolParams) = ???
 
 }
 
@@ -281,3 +293,4 @@ object ScalametaLanguageServer {
     subscriber -> semanticdbPublisher
   }
 }
+

--- a/metaserver/src/main/scala/scala/meta/languageserver/SymbolIndexer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/SymbolIndexer.scala
@@ -9,14 +9,16 @@ import monix.execution.Scheduler
 import monix.reactive.Observable
 import org.langmeta.io.RelativePath
 import ScalametaEnrichments._
-import langserver.core.Connection
-import langserver.messages.MessageType
+
+import org.eclipse.lsp4j.services.LanguageClient
+import org.eclipse.lsp4j.MessageParams
+import org.eclipse.lsp4j.MessageType
 
 // NOTE(olafur) it would make a lot of sense to use tries where Symbol is key.
 class SymbolIndexer(
     val indexer: Observable[Unit],
     logger: Logger,
-    connection: Connection,
+    client: LanguageClient,
     buffers: Buffers,
     documents: JMap[RelativePath, Document],
     definitions: JMap[Symbol, Position.Range],
@@ -125,10 +127,10 @@ class SymbolIndexer(
       // NOTE(olafur) it may be a bit annoying to bail on a single character
       // edit in the file. In the future, we can try more to make sense of
       // partially fresh files using something like edit distance.
-      connection.showMessage(
+      client.showMessage(new MessageParams(
         MessageType.Warning,
         "Please recompile for up-to-date information"
-      )
+      ))
       None
     }
   }
@@ -161,7 +163,7 @@ object SymbolIndexer {
   def apply(
       semanticdbs: Observable[Database],
       logger: Logger,
-      connection: Connection,
+      client: LanguageClient,
       buffers: Buffers
   )(implicit s: Scheduler): SymbolIndexer = {
     val documents =
@@ -233,7 +235,7 @@ object SymbolIndexer {
     new SymbolIndexer(
       indexer,
       logger,
-      connection,
+      client,
       buffers,
       documents,
       definitions,


### PR DESCRIPTION
This PR replaces dragos-vscode-scala LSP bindings with lsp4j.

The reason for this change is that lsp4j is a complete implementation of the LSP, as per the specification. This saves us adding new bindings on demand.

The downside is some "javosity" creeping into `ScalametaLanguageServer` code, but nothing too awful.

Currently this compiles but it throws a runtime exception about some JSON-RPC error that I'm trying to debug.