### PR TITLE
Fixing symbols hierarchy

### DIFF
--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaEnrichments.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaEnrichments.scala
@@ -13,6 +13,7 @@ object ScalametaEnrichments {
   implicit class XtensionTreeLSP(val tree: m.Tree) extends AnyVal {
     import scala.meta._
 
+    // TODO(alexey) function inside a block/if/for/etc.?
     def isFunction: Boolean = tree match {
       case d @ Decl.Val(_) => d.decltpe.is[Type.Function]
       case d @ Decl.Var(_) => d.decltpe.is[Type.Function]
@@ -25,7 +26,7 @@ object ScalametaEnrichments {
       case _ => false
     }
 
-    // we care only about descendants of Member.Type and Member.Term
+    // NOTE: we care only about descendants of Decl, Defn and Pkg[.Object] (see documentSymbols implementation)
     def symbolKind: SymbolKind = tree match {
       case f if f.isFunction => SymbolKind.Function
       case Decl.Var(_)  | Defn.Var(_)  => SymbolKind.Variable
@@ -38,6 +39,7 @@ object ScalametaEnrichments {
       case Defn.Object(_) => SymbolKind.Namespace
       case Pkg.Object(_)  => SymbolKind.Module
       case Pkg(_)         => SymbolKind.Package
+      // TODO(alexey) are these kinds useful?
       // case ??? => SymbolKind.Enum
       // case ??? => SymbolKind.String
       // case ??? => SymbolKind.Number

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaEnrichments.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaEnrichments.scala
@@ -36,8 +36,8 @@ object ScalametaEnrichments {
       case Defn.Macro(_)  => SymbolKind.Constructor
       case Defn.Class(_)  => SymbolKind.Class
       case Defn.Trait(_)  => SymbolKind.Interface
-      case Defn.Object(_) => SymbolKind.Namespace
-      case Pkg.Object(_)  => SymbolKind.Module
+      case Defn.Object(_) => SymbolKind.Module
+      case Pkg.Object(_)  => SymbolKind.Namespace
       case Pkg(_)         => SymbolKind.Package
       // TODO(alexey) are these kinds useful?
       // case ??? => SymbolKind.Enum

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaEnrichments.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaEnrichments.scala
@@ -14,16 +14,15 @@ object ScalametaEnrichments {
     import scala.meta._
 
     // TODO(alexey) function inside a block/if/for/etc.?
-    def isFunction: Boolean = tree match {
-      case d @ Decl.Val(_) => d.decltpe.is[Type.Function]
-      case d @ Decl.Var(_) => d.decltpe.is[Type.Function]
-      case d @ Defn.Val(_) =>
-        d.decltpe.map(_.is[Type.Function]) getOrElse
-        d.rhs.is[Term.Function]
-      case d @ Defn.Var(_) =>
-        d.decltpe.map(_.is[Type.Function]) orElse
-        d.rhs.map(_.is[Term.Function]) getOrElse false
-      case _ => false
+    def isFunction: Boolean = {
+      val tpeOpt: Option[Type] = tree match {
+        case d @ Decl.Val(_) => Some(d.decltpe)
+        case d @ Decl.Var(_) => Some(d.decltpe)
+        case d @ Defn.Val(_) => d.decltpe
+        case d @ Defn.Var(_) => d.decltpe
+        case _ => None
+      }
+      tpeOpt.filter(_.is[Type.Function]).nonEmpty
     }
 
     // NOTE: we care only about descendants of Decl, Defn and Pkg[.Object] (see documentSymbols implementation)

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaEnrichments.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaEnrichments.scala
@@ -10,21 +10,40 @@ import langserver.{types => l}
 object ScalametaEnrichments {
   type SymbolKind = Int
 
-  implicit class XtensionDenotationLSP(val denotation: m.Denotation)
-      extends AnyVal {
-    import denotation._
-    // copy-pasta from metadoc!
-    def symbolKind: SymbolKind = {
-      if (isParam || isTypeParam) SymbolKind.Variable // ???
-      else if (isVal || isVar) SymbolKind.Variable
-      else if (isDef) SymbolKind.Function
-      else if (isPrimaryCtor || isSecondaryCtor) SymbolKind.Constructor
-      else if (isClass) SymbolKind.Class
-      else if (isObject) SymbolKind.Module
-      else if (isTrait) SymbolKind.Interface
-      else if (isPackage || isPackageObject) SymbolKind.Package
-      else if (isType) SymbolKind.Namespace
-      else SymbolKind.Variable // ???
+  implicit class XtensionTreeLSP(val tree: m.Tree) extends AnyVal {
+    import scala.meta._
+
+    def isFunction: Boolean = tree match {
+      case d @ Decl.Val(_) => d.decltpe.is[Type.Function]
+      case d @ Decl.Var(_) => d.decltpe.is[Type.Function]
+      case d @ Defn.Val(_) =>
+        d.decltpe.map(_.is[Type.Function]) getOrElse
+        d.rhs.is[Term.Function]
+      case d @ Defn.Var(_) =>
+        d.decltpe.map(_.is[Type.Function]) orElse
+        d.rhs.map(_.is[Term.Function]) getOrElse false
+      case _ => false
+    }
+
+    // we care only about descendants of Member.Type and Member.Term
+    def symbolKind: SymbolKind = tree match {
+      case f if f.isFunction => SymbolKind.Function
+      case Decl.Var(_)  | Defn.Var(_)  => SymbolKind.Variable
+      case Decl.Val(_)  | Defn.Val(_)  => SymbolKind.Constant
+      case Decl.Def(_)  | Defn.Def(_)  => SymbolKind.Method
+      case Decl.Type(_) | Defn.Type(_) => SymbolKind.Field
+      case Defn.Macro(_)  => SymbolKind.Constructor
+      case Defn.Class(_)  => SymbolKind.Class
+      case Defn.Trait(_)  => SymbolKind.Interface
+      case Defn.Object(_) => SymbolKind.Namespace
+      case Pkg.Object(_)  => SymbolKind.Module
+      case Pkg(_)         => SymbolKind.Package
+      // case ??? => SymbolKind.Enum
+      // case ??? => SymbolKind.String
+      // case ??? => SymbolKind.Number
+      // case ??? => SymbolKind.Boolean
+      // case ??? => SymbolKind.Array
+      case _ => SymbolKind.Field
     }
   }
   implicit class XtensionInputLSP(val input: m.Input) extends AnyVal {

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
@@ -201,12 +201,7 @@ class ScalametaLanguageServer(
       td: TextDocumentIdentifier
   ): Seq[SymbolInformation] = {
     val path = Uri.toPath(td.uri).get
-    symbol.documentSymbols(path.toRelative(cwd)).map {
-      case (position, denotation @ Denotation(_, name, signature, _)) =>
-        val location = path.toLocation(position)
-        val kind = denotation.symbolKind
-        SymbolInformation(name, kind, location, Some(signature))
-    }
+    symbol.documentSymbols(path.toRelative(cwd))
   }
 
   override def gotoDefinitionRequest(

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
@@ -238,7 +238,7 @@ class ScalametaLanguageServer(
       defn <- if (node.is[Pkg]) Some(node) else wrappingDefinition(node)
     } yield SymbolInformation(
       name,
-      1, // TODO(alexey) add conversion from Tree to LSP SymbolKind
+      defn.symbolKind,
       path.toLocation(defn.pos),
       defn.parent
         .flatMap(wrappingDefinition)

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
@@ -213,6 +213,11 @@ class ScalametaLanguageServer(
       else t.parent.flatMap(wrappingDefinition)
     }
 
+    def parentMember(t: Tree): Option[Tree] = {
+      if (t.is[Member.Term] || t.is[Member.Type]) Some(t)
+      else t.parent.flatMap(parentMember)
+    }
+
     // This is needed only to unfold full package names
     def qualifiedName(t: Tree): Option[String] = t match {
       case Term.Name(name) =>
@@ -241,6 +246,7 @@ class ScalametaLanguageServer(
       defn.symbolKind,
       path.toLocation(defn.pos),
       defn.parent
+        .flatMap(parentMember)
         .flatMap(wrappingDefinition)
         .flatMap(qualifiedName)
     )

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
@@ -200,8 +200,50 @@ class ScalametaLanguageServer(
   override def documentSymbols(
       td: TextDocumentIdentifier
   ): Seq[SymbolInformation] = {
+    import scala.meta._
+
+    // For a given node returns its closest ancestor which is a definition, declaration or a package object
+    // NOTE: package is not considered a wrapping definition, but it could be (a subject to discuss)
+    def wrappingDefinition(t: Tree): Option[Tree] = {
+      if (
+        t.is[Defn] ||
+        t.is[Decl] ||
+        t.is[Pkg.Object]
+      ) Some(t)
+      else t.parent.flatMap(wrappingDefinition)
+    }
+
+    // This is needed only to unfold full package names
+    def qualifiedName(t: Tree): Option[String] = t match {
+      case Term.Name(name) =>
+        Some(name)
+      case Term.Select(qual, name) =>
+        qualifiedName(qual).map { prefix => s"${prefix}.${name}" }
+      case Pkg(sel: Term.Select, _) =>
+        qualifiedName(sel)
+      case m: Member =>
+        Some(m.name.value)
+      case _ => None
+    }
+
     val path = Uri.toPath(td.uri).get
-    symbol.documentSymbols(path.toRelative(cwd))
+    val contents = buffers.read(path)
+    for {
+      tree <- contents.parse[Source].toOption.toList
+      node <- tree.collect {
+        case n if n.is[Member.Type] || n.is[Member.Term] => n
+      }
+      name <- qualifiedName(node)
+      // Package as a wrapping definition for itself:
+      defn <- if (node.is[Pkg]) Some(node) else wrappingDefinition(node)
+    } yield SymbolInformation(
+      name,
+      1, // TODO(alexey) add conversion from Tree to LSP SymbolKind
+      path.toLocation(defn.pos),
+      defn.parent
+        .flatMap(wrappingDefinition)
+        .flatMap(qualifiedName)
+    )
   }
 
   override def gotoDefinitionRequest(

--- a/metaserver/src/main/scala/scala/meta/languageserver/SymbolIndexer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/SymbolIndexer.scala
@@ -38,31 +38,6 @@ class SymbolIndexer(
       } => member.pos
     }.headOption
 
-  def documentSymbols(
-      path: RelativePath
-  ): Seq[SymbolInformation] = {
-    for {
-      document <- Option(documents.get(path)).toList
-      _ <- isFreshSemanticdb(path, document).toList
-      tree <- document.input.parse[Source].toOption.toList
-      ResolvedName(pos, symbol: Symbol.Global, true) <- document.names
-      denotation <- Option(denotations.get(symbol))
-      if ! {
-        import denotation._
-        isPrimaryCtor ||
-        isTypeParam ||
-        isParam
-      } // not interesting for this service
-    } yield SymbolInformation(
-      denotation.name,
-      denotation.symbolKind,
-      path.toAbsolute.toLocation(
-        definitionPos(tree, pos, denotation.name).getOrElse(pos)
-      ),
-      Option(denotations.get(symbol.owner)).map(_.name)
-    )
-  }
-
   def goToDefinition(
       path: RelativePath,
       line: Int,
@@ -173,10 +148,10 @@ class SymbolIndexer(
       // NOTE(olafur) it may be a bit annoying to bail on a single character
       // edit in the file. In the future, we can try more to make sense of
       // partially fresh files using something like edit distance.
-      connection.showMessage(
-        MessageType.Warning,
-        "Please recompile for up-to-date information"
-      )
+      // connection.showMessage(
+      //   MessageType.Warning,
+      //   "Please recompile for up-to-date information"
+      // )
       None
     }
   }

--- a/metaserver/src/main/scala/scala/meta/languageserver/SymbolIndexer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/SymbolIndexer.scala
@@ -13,7 +13,6 @@ import org.langmeta.io.RelativePath
 import ScalametaEnrichments._
 import langserver.core.Connection
 import langserver.messages.MessageType
-import langserver.types.SymbolInformation
 
 // NOTE(olafur) it would make a lot of sense to use tries where Symbol is key.
 class SymbolIndexer(
@@ -29,14 +28,6 @@ class SymbolIndexer(
       Map[RelativePath, List[Position]]
     ]
 )(implicit cwd: AbsolutePath) {
-
-  def definitionPos(tree: Source, pos: Position, name: String): Option[Position] =
-    tree.collect {
-      case member: Member if {
-        member.pos.startLine == pos.startLine &&
-        member.name.value == name
-      } => member.pos
-    }.headOption
 
   def goToDefinition(
       path: RelativePath,
@@ -148,10 +139,10 @@ class SymbolIndexer(
       // NOTE(olafur) it may be a bit annoying to bail on a single character
       // edit in the file. In the future, we can try more to make sense of
       // partially fresh files using something like edit distance.
-      // connection.showMessage(
-      //   MessageType.Warning,
-      //   "Please recompile for up-to-date information"
-      // )
+      connection.showMessage(
+        MessageType.Warning,
+        "Please recompile for up-to-date information"
+      )
       None
     }
   }


### PR DESCRIPTION
WIP fix for #33.

Here's how it looks with 379a735:
![screen shot 2017-11-12 at 21 24 06](https://user-images.githubusercontent.com/766656/32704072-ec6d937a-c7ff-11e7-90b7-921171546150.png)

The problem is, it shows only one level of nesting, which is wrong. I compared the responses with other servers (TypeScript and Python) and didn't find any difference: `containerName` just matches the corresponding symbol's `name` field, nothing special. 