### PR TITLE
Use .toLongString instead of .widen.toString in typeOfTree

### DIFF
--- a/metaserver/src/main/scala/scala/meta/languageserver/Compiler.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Compiler.scala
@@ -157,7 +157,7 @@ class Compiler(
       case x => x
     }
 
-    Option(refinedTree.tpe).map(_.widen.toString)
+    Option(refinedTree.tpe).map(_.toLongString)
   }
 
 }


### PR DESCRIPTION
Apparently `toLongString` handles a bunch of edge cases on top of `.widen`. Thanks @olafurpg for the tip.

https://github.com/scala/scala/blob/07d61ecf134dbba143531f5a1bd3c1289c437296/src/reflect/scala/reflect/internal/Types.scala#L953-L964