### PR TITLE
Use leveldb to cache computation of ctags indices

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,3 +84,34 @@ sbt
 > metaserver/testOnly -- tests.ctags  # Only test the ctags tests
 > metaserver/testOnly -- tests.search # Only test the symbol indexer tests
 ```
+
+## Clearing index cache
+
+This project caches globally in the computed symbol indices from your
+source classpath.
+This is done to prevent reindexing large dependencies like the JDK
+(which has ~2.5 million lines of code) on every editor startup.
+This directory where this cache is stored depends on your OS and is
+computed using [soc/directories](https://github.com/soc/directories)
+using the project name "metaserver".
+For example, on a Mac this directory is ~/Library/Caches/metaserver/.
+While developing this project, you may encounter the need to need
+`rm -rf` this cache directory to re-trigger indexing for some reason.
+
+
+## Troubleshooting
+
+- If SymbolIndexerTest.classpath tests fail with missing definitions for
+  `List` or `CharRef`, try to run `*:scalametaEnableCompletions` from the
+  sbt shell and then re-run. This command must be re-run after every
+  `clean`.
+- If you get the following error
+
+      org.fusesource.leveldbjni.internal.NativeDB$DBException: IO error: lock /path/to/Library/Cache/metaserver
+
+  that means you are running two scalameta/language-server instances
+  that are competing for the same lock on the global cache.
+  Try to turn off your editor (vscode/atom) while running the test suite
+  locally.
+  We hope to address this in the future by for example moving the cache to
+  each workspace directory or use an alternative storing mechanism.

--- a/build.sbt
+++ b/build.sbt
@@ -75,7 +75,10 @@ lazy val metaserver = project
     ),
     resolvers += Resolver.bintrayRepo("dhpcs", "maven"),
     testFrameworks := new TestFramework("utest.runner.Framework") :: Nil,
+    fork in Test := true,
     libraryDependencies ++= List(
+      "io.github.soc" % "directories" % "5",
+      "org.fusesource.leveldbjni" % "leveldbjni-all" % "1.8",
       "io.monix" %% "monix" % "2.3.0",
       "com.lihaoyi" %% "pprint" % "0.5.3",
       "com.thoughtworks.qdox" % "qdox" % "2.0-M7", // for java ctags

--- a/build.sbt
+++ b/build.sbt
@@ -75,9 +75,10 @@ lazy val metaserver = project
     ),
     resolvers += Resolver.bintrayRepo("dhpcs", "maven"),
     testFrameworks := new TestFramework("utest.runner.Framework") :: Nil,
-    fork in Test := true,
+    fork in Test := true, // required for jni interrop with leveldb.
     buildInfoKeys := Seq[BuildInfoKey](
-      "testWorkspaceBaseDirectory" -> baseDirectory.in(testWorkspace).value.getParent
+      "testWorkspaceBaseDirectory" ->
+        baseDirectory.in(testWorkspace).value.getParent
     ),
     buildInfoPackage := "scala.meta.languageserver.internal",
     libraryDependencies ++= List(

--- a/build.sbt
+++ b/build.sbt
@@ -76,6 +76,10 @@ lazy val metaserver = project
     resolvers += Resolver.bintrayRepo("dhpcs", "maven"),
     testFrameworks := new TestFramework("utest.runner.Framework") :: Nil,
     fork in Test := true,
+    buildInfoKeys := Seq[BuildInfoKey](
+      "testWorkspaceBaseDirectory" -> baseDirectory.in(testWorkspace).value.getParent
+    ),
+    buildInfoPackage := "scala.meta.languageserver.internal",
     libraryDependencies ++= List(
       "io.github.soc" % "directories" % "5",
       "org.fusesource.leveldbjni" % "leveldbjni-all" % "1.8",
@@ -93,6 +97,7 @@ lazy val metaserver = project
     languageserver,
     testWorkspace % "test->test"
   )
+  .enablePlugins(BuildInfoPlugin)
 
 lazy val testWorkspace = project
   .in(file("test-workspace") / "a")

--- a/metaserver/src/main/scala/scala/meta/languageserver/Compiler.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Compiler.scala
@@ -118,9 +118,8 @@ class Compiler(
         s"Indexing classpath with ${sourcesClasspath.length} entries..."
       )
     }
-    ctags.Ctags.index(sourcesClasspath) { doc =>
-      documentSubscriber.onNext(doc)
-    }
+    val db = ctags.Ctags.indexDatabase(sourcesClasspath)
+    db.documents.foreach(documentSubscriber.onNext)
     Effects.IndexSourcesClasspath
   }
   private def noCompletions: List[(String, String)] = {

--- a/metaserver/src/main/scala/scala/meta/languageserver/Compiler.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Compiler.scala
@@ -105,7 +105,8 @@ class Compiler(
     Effects.InstallPresentationCompiler
   }
 
-  // NOTE(olafur) this probably belongs somewhere else than Compiler.
+  // NOTE(olafur) this probably belongs somewhere else than Compiler, see
+  // https://github.com/scalameta/language-server/issues/48
   def indexDependencyClasspath(
       sourceJars: List[AbsolutePath]
   ): Effects.IndexSourcesClasspath = {

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
@@ -58,7 +58,7 @@ class ScalametaLanguageServer(
     logger.error(e.getMessage, e)
   }
   var leveldb: DB = _
-  var indexingCache: LevelDBMap[AbsolutePath, Database] = _
+  var indexingCache: LevelDBMap = _
   def initializeIndexingCache(): Unit = {
     val leveldbCacheDirectory = cacheDirectory.resolve("leveldb").toFile
     logger.info(
@@ -67,9 +67,7 @@ class ScalametaLanguageServer(
     leveldb = LevelDBMap.createDBThatIPromiseToClose(leveldbCacheDirectory)
     // TODO(olafur) store some version ID in the cached Database in order
     // to be able to invalidate old caches when our indexing algorithms change.
-    indexingCache = LevelDBMap[String, Array[Byte]](leveldb)
-      .mapKeys[AbsolutePath](AbsolutePath.apply, _.toString)
-      .mapValues[Database](Database.parseFrom, _.toByteArray)
+    indexingCache = LevelDBMap(leveldb)
   }
   val buffers: Buffers = Buffers()
   val compiler = new Compiler(

--- a/metaserver/src/main/scala/scala/meta/languageserver/storage/Bytes.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/storage/Bytes.scala
@@ -1,0 +1,25 @@
+package scala.meta.languageserver.storage
+
+import java.nio.charset.StandardCharsets
+
+trait Bytes[A] { self =>
+  def fromBytes(bytes: Array[Byte]): A
+  def toBytes(e: A): Array[Byte]
+  def map[B](f: A => B, g: B => A): Bytes[B] = new Bytes[B] {
+    override def fromBytes(bytes: Array[Byte]) = f(self.fromBytes(bytes))
+    override def toBytes(e: B): Array[Byte] = self.toBytes(g(e))
+  }
+}
+
+object Bytes {
+  implicit val StringBytes: Bytes[String] = new Bytes[String] {
+    override def fromBytes(bytes: Array[Byte]): String =
+      new String(bytes, StandardCharsets.UTF_8)
+    override def toBytes(e: String): Array[Byte] =
+      e.getBytes(StandardCharsets.UTF_8)
+  }
+  implicit val ByteArrayBytes: Bytes[Array[Byte]] = new Bytes[Array[Byte]] {
+    override def toBytes(e: Array[Byte]): Array[Byte] = e
+    override def fromBytes(bytes: Array[Byte]): Array[Byte] = bytes
+  }
+}

--- a/metaserver/src/main/scala/scala/meta/languageserver/storage/Bytes.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/storage/Bytes.scala
@@ -1,25 +1,35 @@
 package scala.meta.languageserver.storage
 
 import java.nio.charset.StandardCharsets
+import org.langmeta.internal.semanticdb.schema.Database
+import org.langmeta.io.AbsolutePath
 
-trait Bytes[A] { self =>
+trait FromBytes[A] { self =>
   def fromBytes(bytes: Array[Byte]): A
-  def toBytes(e: A): Array[Byte]
-  def map[B](f: A => B, g: B => A): Bytes[B] = new Bytes[B] {
-    override def fromBytes(bytes: Array[Byte]) = f(self.fromBytes(bytes))
-    override def toBytes(e: B): Array[Byte] = self.toBytes(g(e))
-  }
+  def map[B](f: A => B): FromBytes[B] =
+    bytes => f(self.fromBytes(bytes))
+}
+object FromBytes {
+  implicit val StringFromBytes: FromBytes[String] =
+    new String(_, StandardCharsets.UTF_8)
+  implicit val ByteArrayFromBytes: FromBytes[Array[Byte]] =
+    identity[Array[Byte]]
+  implicit val DatabaseFromBytes: FromBytes[Database] =
+    bytes => Database.parseFrom(bytes)
 }
 
-object Bytes {
-  implicit val StringBytes: Bytes[String] = new Bytes[String] {
-    override def fromBytes(bytes: Array[Byte]): String =
-      new String(bytes, StandardCharsets.UTF_8)
-    override def toBytes(e: String): Array[Byte] =
-      e.getBytes(StandardCharsets.UTF_8)
-  }
-  implicit val ByteArrayBytes: Bytes[Array[Byte]] = new Bytes[Array[Byte]] {
-    override def toBytes(e: Array[Byte]): Array[Byte] = e
-    override def fromBytes(bytes: Array[Byte]): Array[Byte] = bytes
-  }
+trait ToBytes[A] { self =>
+  def toBytes(e: A): Array[Byte]
+  def map[B](f: B => A): ToBytes[B] =
+    e => self.toBytes(f(e))
+}
+object ToBytes {
+  implicit val StringToBytes: ToBytes[String] =
+    _.getBytes(StandardCharsets.UTF_8)
+  implicit val ByteArrayToBytes: ToBytes[Array[Byte]] =
+    identity[Array[Byte]]
+  implicit val DatabaseToBytes: ToBytes[Database] =
+    _.toByteArray
+  implicit val AbsolutePathToBytes: ToBytes[AbsolutePath] =
+    _.toString().getBytes(StandardCharsets.UTF_8)
 }

--- a/metaserver/src/main/scala/scala/meta/languageserver/storage/Bytes.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/storage/Bytes.scala
@@ -20,7 +20,7 @@ object FromBytes {
 
 trait ToBytes[A] { self =>
   def toBytes(e: A): Array[Byte]
-  def map[B](f: B => A): ToBytes[B] =
+  def contramap[B](f: B => A): ToBytes[B] =
     e => self.toBytes(f(e))
 }
 object ToBytes {

--- a/metaserver/src/main/scala/scala/meta/languageserver/storage/LevelDBMap.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/storage/LevelDBMap.scala
@@ -18,18 +18,13 @@ import org.iq80.leveldb.Options
 class LevelDBMap(db: DB) extends LazyLogging {
 
   /** Returns the value matching key, if any. */
+  @throws[DBException]
   def get[Key, Value](key: Key)(
       implicit
       keys: ToBytes[Key],
       values: FromBytes[Value]
   ): Option[Value] = {
-    try {
-      Option(db.get(keys.toBytes(key))).map(values.fromBytes)
-    } catch {
-      case e: DBException =>
-        logger.error(e.getMessage, e)
-        None
-    }
+    Option(db.get(keys.toBytes(key))).map(values.fromBytes)
   }
 
   /**
@@ -37,6 +32,7 @@ class LevelDBMap(db: DB) extends LazyLogging {
    *
    * This method is not thread-safe, the computed fallback value may get overwritten.
    */
+  @throws[DBException]
   def getOrElseUpdate[Key, Value](key: Key, orElse: () => Value)(
       implicit
       keys: ToBytes[Key],
@@ -52,19 +48,14 @@ class LevelDBMap(db: DB) extends LazyLogging {
   }
 
   /** Inserts a new value for the given key. */
+  @throws[DBException]
   def put[Key, Value](key: Key, value: Value)(
       implicit
       keys: ToBytes[Key],
       values: ToBytes[Value]
   ): Value = {
-    try {
-      db.put(keys.toBytes(key), values.toBytes(value))
-      value
-    } catch {
-      case e: DBException =>
-        logger.error(e.getMessage, e)
-        value
-    }
+    db.put(keys.toBytes(key), values.toBytes(value))
+    value
   }
 
   def close(): Unit = db.close()

--- a/metaserver/src/main/scala/scala/meta/languageserver/storage/LevelDBMap.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/storage/LevelDBMap.scala
@@ -12,22 +12,15 @@ import org.iq80.leveldb.Options
  *
  * @param db The leveldb, remember to close it after using. This wrapper will NOT
  *           close the db for you.
- * @param keys type-class to read/write key values from arrays of bytes.
- * @param values type-class to read/write key values from arrays of bytes.
  */
-class LevelDBMap[Key, Value](db: DB, keys: Bytes[Key], values: Bytes[Value])
-    extends LazyLogging {
-
-  /** Returns new wrapper where the keys are parsed into T. */
-  def mapValues[T](f: Value => T, g: T => Value): LevelDBMap[Key, T] =
-    new LevelDBMap(db, keys, values.map(f, g))
-
-  /** Returns new wrapper where the values are parsed into T. */
-  def mapKeys[T](f: Key => T, g: T => Key): LevelDBMap[T, Value] =
-    new LevelDBMap(db, keys.map(f, g), values)
+class LevelDBMap(db: DB) extends LazyLogging {
 
   /** Returns the value matching key, if any. */
-  def get(key: Key): Option[Value] = {
+  def get[Key, Value](key: Key)(
+      implicit
+      keys: ToBytes[Key],
+      values: FromBytes[Value]
+  ): Option[Value] = {
     try {
       Option(db.get(keys.toBytes(key))).map(values.fromBytes)
     } catch {
@@ -42,7 +35,12 @@ class LevelDBMap[Key, Value](db: DB, keys: Bytes[Key], values: Bytes[Value])
    *
    * This method is not thread-safe, the computed fallback value may get overwritten.
    */
-  def getOrElseUpdate(key: Key, orElse: () => Value): Value = {
+  def getOrElseUpdate[Key, Value](key: Key, orElse: () => Value)(
+      implicit
+      keys: ToBytes[Key],
+      valuesFrom: FromBytes[Value],
+      valuesTo: ToBytes[Value]
+  ): Value = {
     get(key) match {
       case Some(value) => value
       case None =>
@@ -52,7 +50,11 @@ class LevelDBMap[Key, Value](db: DB, keys: Bytes[Key], values: Bytes[Value])
   }
 
   /** Inserts a new value for the given key. */
-  def put(key: Key, value: Value): Value = {
+  def put[Key, Value](key: Key, value: Value)(
+      implicit
+      keys: ToBytes[Key],
+      values: ToBytes[Value]
+  ): Value = {
     try {
       db.put(keys.toBytes(key), values.toBytes(value))
       value
@@ -68,20 +70,9 @@ class LevelDBMap[Key, Value](db: DB, keys: Bytes[Key], values: Bytes[Value])
 
 object LevelDBMap {
 
-  /**
-   * Construct new wrapper around a leveldb.
-   *
-   * @tparam T Good values are either String or Array[Byte]. Use mapValues/mapKeys
-   *           to use higher level types than String/Array[Byte] for values or keys.
-   */
-  def apply[T](db: DB)(implicit ev: Bytes[T]): LevelDBMap[T, T] =
-    new LevelDBMap(db, ev, ev)
-
-  def apply[Key, Value](db: DB)(
-      implicit keys: Bytes[Key],
-      values: Bytes[Value]
-  ): LevelDBMap[Key, Value] =
-    new LevelDBMap(db, keys, values)
+  /** Construct new wrapper around a leveldb. */
+  def apply(db: DB): LevelDBMap =
+    new LevelDBMap(db)
 
   /**
    * Creates a new leveldb in the given directory.
@@ -91,6 +82,7 @@ object LevelDBMap {
   def createDBThatIPromiseToClose(directory: File): DB = {
     val options = new Options
     options.createIfMissing(true)
+    options.maxOpenFiles()
     JniDBFactory.factory.open(directory, options)
   }
 

--- a/metaserver/src/main/scala/scala/meta/languageserver/storage/LevelDBMap.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/storage/LevelDBMap.scala
@@ -1,0 +1,73 @@
+package scala.meta.languageserver.storage
+
+import java.io.File
+import com.typesafe.scalalogging.LazyLogging
+import org.fusesource.leveldbjni.JniDBFactory
+import org.iq80.leveldb.DB
+import org.iq80.leveldb.DBException
+import org.iq80.leveldb.Options
+
+/**
+ * A Scala-friendly wrapper around the JniDBFactory Java-wrapper around leveldb.
+ *
+ * @param db The leveldb, remember to close it after using. This wrapper will NOT
+ *           close the db for you.
+ * @param keys type-class to read/write key values from arrays of bytes.
+ * @param values type-class to read/write key values from arrays of bytes.
+ */
+class LevelDBMap[Key, Value](db: DB, keys: Bytes[Key], values: Bytes[Value])
+    extends LazyLogging {
+
+  /** Returns new wrapper where the keys are parsed into T. */
+  def mapValues[T](f: Value => T, g: T => Value): LevelDBMap[Key, T] =
+    new LevelDBMap(db, keys, values.map(f, g))
+
+  /** Returns new wrapper where the values are parsed into T. */
+  def mapKeys[T](f: Key => T, g: T => Key): LevelDBMap[T, Value] =
+    new LevelDBMap(db, keys.map(f, g), values)
+
+  /** Returns the value matching key, if any. */
+  def get(key: Key): Option[Value] = {
+    try {
+      Option(db.get(keys.toBytes(key))).map(values.fromBytes)
+    } catch {
+      case e: DBException =>
+        logger.error(e.getMessage, e)
+        None
+    }
+  }
+
+  /** Inserts a new value for the given key. */
+  def put(key: Key, value: Value): Unit = {
+    try {
+      db.put(keys.toBytes(key), values.toBytes(value))
+    } catch {
+      case e: DBException =>
+        logger.error(e.getMessage, e)
+    }
+  }
+}
+
+object LevelDBMap {
+
+  /**
+   * Construct new wrapper around a leveldb.
+   *
+   * @tparam T Good values are either String or Array[Byte]. Use mapValues/mapKeys
+   *           to use higher level types than String/Array[Byte] for values or keys.
+   */
+  def apply[T](db: DB)(implicit ev: Bytes[T]): LevelDBMap[T, T] =
+    new LevelDBMap(db, ev, ev)
+
+  /**
+   * Creates a new leveldb in the given directory.
+   *
+   * Make sure to `db.close()`.
+   */
+  def createDBThatIPromiseToClose(directory: File): DB = {
+    val options = new Options
+    options.createIfMissing(true)
+    JniDBFactory.factory.open(directory, options)
+  }
+
+}

--- a/metaserver/src/test/scala/tests/search/SymbolIndexTest.scala
+++ b/metaserver/src/test/scala/tests/search/SymbolIndexTest.scala
@@ -4,6 +4,8 @@ import java.io.PipedInputStream
 import java.io.PipedOutputStream
 import java.nio.file.Files
 import java.nio.file.Paths
+
+import scala.meta.languageserver.internal.BuildInfo
 import scala.meta.languageserver.ScalametaLanguageServer
 import scala.meta.languageserver.ServerConfig
 import scala.meta.languageserver.search.InverseSymbolIndexer
@@ -19,7 +21,7 @@ import utest._
 
 object SymbolIndexTest extends MegaSuite {
   implicit val cwd: AbsolutePath =
-    PathIO.workingDirectory.resolve("test-workspace")
+    AbsolutePath(BuildInfo.testWorkspaceBaseDirectory)
   val path = cwd
     .resolve("a")
     .resolve("src")
@@ -27,12 +29,12 @@ object SymbolIndexTest extends MegaSuite {
     .resolve("scala")
     .resolve("example")
     .resolve("UserTest.scala")
-  assert(Files.isRegularFile(path.toNIO))
+  Predef.assert(Files.isRegularFile(path.toNIO), path.toString())
   val s = TestScheduler()
   val config = ServerConfig(
     cwd,
     setupScalafmt = false,
-    indexJDK = false,
+    indexJDK = false, // TODO(olafur) enabling this breaks go to definition
     indexClasspath = true // set to false to speedup edit/debug cycle
   )
   val client = new PipedOutputStream()

--- a/metaserver/src/test/scala/tests/storage/LevelDBMapTest.scala
+++ b/metaserver/src/test/scala/tests/storage/LevelDBMapTest.scala
@@ -31,6 +31,16 @@ object LevelDBMapTest extends MegaSuite {
     assert(intMap.get(2).isEmpty)
   }
 
+  test("getOrElseUpdate") {
+    var count = 0
+    val obtained =
+      map.getOrElseUpdate("unknown", () => { count += 1; count.toString })
+    assert(obtained == "1")
+    val obtained2 =
+      map.getOrElseUpdate("unknown", () => { count += 1; count.toString })
+    assert(obtained2 == "1")
+  }
+
   override def utestAfterAll(): Unit = {
     db.close()
   }

--- a/metaserver/src/test/scala/tests/storage/LevelDBMapTest.scala
+++ b/metaserver/src/test/scala/tests/storage/LevelDBMapTest.scala
@@ -22,7 +22,7 @@ object LevelDBMapTest extends MegaSuite {
     case class User(name: String)
     object User {
       implicit val UserToBytes: ToBytes[User] =
-        ToBytes.StringToBytes.map[User](_.name)
+        ToBytes.StringToBytes.contramap[User](_.name)
       implicit val UserFromBytes: FromBytes[User] =
         FromBytes.StringFromBytes.map[User](User.apply)
     }

--- a/metaserver/src/test/scala/tests/storage/LevelDBMapTest.scala
+++ b/metaserver/src/test/scala/tests/storage/LevelDBMapTest.scala
@@ -1,0 +1,37 @@
+package tests.storage
+
+import java.nio.file.Files
+import scala.meta.languageserver.storage.LevelDBMap
+import tests.MegaSuite
+
+object LevelDBMapTest extends MegaSuite {
+  val tmp = Files.createTempDirectory("metaserver").toFile
+  tmp.deleteOnExit()
+  val db = LevelDBMap.createDBThatIPromiseToClose(tmp)
+  val map = LevelDBMap[String](db)
+
+  test("get/put") {
+    map.put("key", "value")
+    assert(map.get("key").contains("value"))
+    assert(map.get("blah").isEmpty)
+  }
+
+  test("mapValues") {
+    case class User(name: String)
+    val userMap = map.mapValues[User](User.apply, _.name)
+    userMap.put("John", User("John"))
+    assert(userMap.get("John").contains(User("John")))
+    assert(userMap.get("Susan").isEmpty)
+  }
+
+  test("mapKeys") {
+    val intMap = map.mapKeys[Int](_.toInt, _.toString)
+    intMap.put(1, "2")
+    assert(intMap.get(1).contains("2"))
+    assert(intMap.get(2).isEmpty)
+  }
+
+  override def utestAfterAll(): Unit = {
+    db.close()
+  }
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,6 @@
 addSbtPlugin("ch.epfl.scala" % "sbt-release-early" % "1.2.0")
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC13")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")
 addSbtPlugin(
   "com.thesamet" % "sbt-protoc" % "0.99.12" exclude ("com.trueaccord.scalapb", "protoc-bridge_2.10")
 )


### PR DESCRIPTION
This PR makes the server start much faster after the first run. There are still some issues with the implementation in this PR that I plan to address in the future (to avoid making this PR huge!). This PR is already a big enough improvement over master.

One big question is where to store the cache. Should we share cache across workspaces or have one cache per workspace. In this PR I use a global cache since I think that makes sense in the long run. However, it seems leveldb doesn't permit two concurrent connections (unless I'm missing some options to allow it), which makes it problematic to share the cache globally. I'm interested to hear what you think.

