### PR TITLE
Fix sbt-release-early CI deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,3 +31,4 @@ deploy:
     branch: master
     # only if HEAD is a merge commit or a tag:
     condition: '"$(git rev-list --merges HEAD^..HEAD)" || "$TRAVIS_TAG"'
+    condition: '"$CI_TEST" = "ci-fast"'

--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,12 @@ inThisBuild(
         url("https://github.com/laughedelic")
       )
     ),
+    scmInfo in ThisBuild := Some(
+      ScmInfo(
+        url("https://github.com/scalameta/language-server"),
+        s"scm:git:git@github.com:scalameta/language-server.git"
+      )
+    ),
     releaseEarlyWith := BintrayPublisher,
     releaseEarlyEnableSyncToMaven := false,
     publishMavenStyle := true,


### PR DESCRIPTION
Fixing what didn't work in #46:

- [missing](https://travis-ci.org/scalameta/language-server/jobs/306019884#L967) `scmInfo` key
- `deploy` block should be triggered only in one CI job (otherwise it'll try to deploy second time after scalafmt check and fail)