### PR TITLE
Improve logging

### DIFF
--- a/languageserver/src/main/scala/langserver/core/Connection.scala
+++ b/languageserver/src/main/scala/langserver/core/Connection.scala
@@ -38,7 +38,7 @@ class Connection(inStream: InputStream, outStream: OutputStream)(val commandHand
 
   def notifySubscribers(n: Notification): Unit = {
     notificationHandlers.foreach(f =>
-      Try(f(n)).recover { case e => logger.error("failed notification handler", e) })
+      Try(f(n)).recover { case e => logger.error("Failed notification handler", e) })
   }
 
   def sendNotification(params: Notification): Unit = {
@@ -106,7 +106,7 @@ class Connection(inStream: InputStream, outStream: OutputStream)(val commandHand
                 }
 
               case response: JsonRpcResponseMessage =>
-                logger.info(s"Received response: $response")
+                // logger.debug(s"Received response: $response")
 
               case m =>
                 logger.error(s"Received unknown message: $m")
@@ -118,7 +118,6 @@ class Connection(inStream: InputStream, outStream: OutputStream)(val commandHand
   }
 
   private def readJsonRpcMessage(jsonString: String): Either[JsonRpcResponseErrorMessage, JsonRpcMessage] = {
-    logger.debug(s"Received $jsonString")
     Try(Json.parse(jsonString)) match {
       case Failure(exception) =>
         Left(JsonRpcResponseErrorMessage.parseError(exception,NoCorrelationId))

--- a/languageserver/src/main/scala/langserver/core/LanguageServer.scala
+++ b/languageserver/src/main/scala/langserver/core/LanguageServer.scala
@@ -60,28 +60,28 @@ class LanguageServer(inStream: InputStream, outStream: OutputStream) extends Laz
   }
 
   def onOpenTextDocument(td: TextDocumentItem) = {
-    logger.debug(s"openTextDocuemnt $td")
+    logger.debug(s"openTextDocument $td")
   }
 
   def onChangeTextDocument(td: VersionedTextDocumentIdentifier, changes: Seq[TextDocumentContentChangeEvent]) = {
-    logger.debug(s"changeTextDocuemnt $td")
+    logger.debug(s"changeTextDocument $td")
   }
 
   def onSaveTextDocument(td: TextDocumentIdentifier) = {
-    logger.debug(s"saveTextDocuemnt $td")
+    logger.debug(s"saveTextDocument $td")
     connection.showMessage(MessageType.Info, s"Saved text document ${td.uri}")
   }
 
   def onCloseTextDocument(td: TextDocumentIdentifier) = {
-    logger.debug(s"closeTextDocuemnt $td")
+    logger.debug(s"closeTextDocument $td")
   }
 
   def onChangeWatchedFiles(changes: Seq[FileEvent]) = {
-//    ???
+    logger.debug(s"changeWatchedFiles $changes")
   }
 
   def initialize(pid: Long, rootPath: String, capabilities: ClientCapabilities): ServerCapabilities = {
-    logger.info(s"Initialized with $pid, $rootPath, $capabilities")
+    logger.debug(s"initialize with $pid, $rootPath, $capabilities")
     ServerCapabilities(completionProvider = Some(CompletionOptions(false, Seq("."))))
   }
 

--- a/languageserver/src/main/scala/langserver/core/MessageReader.scala
+++ b/languageserver/src/main/scala/langserver/core/MessageReader.scala
@@ -81,7 +81,6 @@ class MessageReader(in: InputStream) extends LazyLogging {
 
     if (atDelimiter(i)) {
       val headers = new String(data.slice(0, i).toArray, MessageReader.AsciiCharset)
-      logger.debug(s"Received headers:\n$headers")
 
       val pairs = headers.split("\r\n").filter(_.trim.length() > 0) map { line =>
         line.split(":") match {
@@ -142,7 +141,10 @@ class MessageReader(in: InputStream) extends LazyLogging {
 
       if (length > 0) {
         val content = getContent(length)
-        if (content.isEmpty() && streamClosed) None else Some(content)
+        if (content.isEmpty() && streamClosed) None else {
+          logger.debug(s"<--  $content")
+          Some(content)
+        }
       } else {
         logger.error("Input must have Content-Length header with a numeric value.")
         nextPayload()
@@ -155,4 +157,3 @@ object MessageReader {
   val AsciiCharset = Charset.forName("ASCII")
   val Utf8Charset = Charset.forName("UTF-8")
 }
-

--- a/languageserver/src/main/scala/langserver/core/MessageWriter.scala
+++ b/languageserver/src/main/scala/langserver/core/MessageWriter.scala
@@ -38,8 +38,7 @@ class MessageWriter(out: OutputStream) extends LazyLogging {
       .map { case (k, v) => s"$k: $v" }
       .mkString("", "\r\n", "\r\n\r\n")
 
-    logger.debug(s"$headers\n\n$str")
-    logger.debug(s"payload: $str")
+    logger.debug(s" --> $str")
 
     val headerBytes = headers.getBytes(MessageReader.AsciiCharset)
 

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
@@ -147,7 +147,7 @@ class ScalametaLanguageServer(
         }
 
       case event =>
-        logger.info(s"Unhandled file event: $event")
+        logger.warn(s"Unhandled file event: $event")
         ()
     }
 


### PR DESCRIPTION
I removed message headers logging and changed a bit how incoming/outcoming messages are logged (from reader/writer):

```
01:50:25.578 INFO  s.m.l.Compiler - Loading new compiler from config CompilerConfig(sources={+1}, scalacOptions=-Yrangepos -P:semanticdb:sourceroot:/Users/laughedelic/dev/laughedelic/language-server/test-workspace -Xplugin:/Users/laughedelic/.coursier/cache/v1/https/repo1.maven.org/maven2/org/scalameta/semanticdb-scalac_2.12.3/2.1.2/semanticdb-scalac_2.12.3-2.1.2.jar, dependencyClasspath={+2}, classDirectory=/Users/laughedelic/dev/laughedelic/language-server/test-workspace/a/target/scala-2.12/test-classes, sourceJars={+13})
01:50:26.134 DEBUG l.core.MessageReader - <--  {"jsonrpc":"2.0","id":3,"method":"textDocument/hover","params":{"textDocument":{"uri":"file:///Users/laughedelic/dev/laughedelic/language-server/test-workspace/a/src/main/scala/example/User.scala"},"position":{"line":2,"character":19}}}
01:50:26.440 DEBUG l.core.MessageWriter -  --> {"jsonrpc":"2.0","result":{"contents":[{"language":"scala","value":"String"}]},"id":3}
01:50:30.341 DEBUG l.core.MessageReader - <--  {"jsonrpc":"2.0","id":4,"method":"textDocument/hover","params":{"textDocument":{"uri":"file:///Users/laughedelic/dev/laughedelic/language-server/test-workspace/a/src/main/scala/example/User.scala"},"position":{"line":5,"character":6}}}
01:50:30.361 DEBUG l.core.MessageWriter -  --> {"jsonrpc":"2.0","result":{"contents":[{"language":"scala","value":"String"}]},"id":4}
01:50:32.417 DEBUG l.core.MessageReader - <--  {"jsonrpc":"2.0","id":5,"method":"textDocument/definition","params":{"textDocument":{"uri":"file:///Users/laughedelic/dev/laughedelic/language-server/test-workspace/a/src/main/scala/example/User.scala"},"position":{"line":5,"character":6}}}
```

Tell me if you don't like arrows or want to change it to something else. I just wanted to make it more lightweight visually.