### PR TITLE
Add Hover Test and fix broken cases

### DIFF
--- a/metaserver/src/main/scala/scala/meta/languageserver/Compiler.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Compiler.scala
@@ -84,7 +84,7 @@ class Compiler(
       case (compiler, position) =>
         val response = ask[compiler.Tree](r => compiler.askTypeAt(position, r))
         val typedTree = response.get.swap
-        typedTree.toOption.flatMap(t => typeOfTree(compiler)(t))
+        typedTree.toOption.flatMap(t => Compiler.typeOfTree(compiler)(t))
     }
   }
 
@@ -172,19 +172,6 @@ class Compiler(
     i + column
   }
 
-  private def typeOfTree(c: Global)(t: c.Tree): Option[String] = {
-    import c._
-
-    val refinedTree = t match {
-      case t: ImplDef if t.impl != null => t.impl
-      case t: ValOrDefDef if t.tpt != null => t.tpt
-      case t: ValOrDefDef if t.rhs != null => t.rhs
-      case x => x
-    }
-
-    Option(refinedTree.tpe).map(_.toLongString)
-  }
-
 }
 
 object Compiler extends LazyLogging {
@@ -217,4 +204,17 @@ object Compiler extends LazyLogging {
     f(r)
     r
   }
+  def typeOfTree(c: Global)(t: c.Tree): Option[String] = {
+    import c._
+
+    val refinedTree = t match {
+      case t: ImplDef if t.impl != null => t.impl
+      case t: ValOrDefDef if t.tpt != null => t.tpt
+      case t: ValOrDefDef if t.rhs != null => t.rhs
+      case x => x
+    }
+
+    Option(refinedTree.tpe).map(_.toLongString)
+  }
+
 }

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
@@ -294,16 +294,7 @@ class ScalametaLanguageServer(
       position: Position
   ): Hover = {
     val path = Uri.toPath(td.uri).get
-    compiler.typeAt(path, position.line, position.character) match {
-      case None => Hover(Nil, None)
-      case Some(tpeName) =>
-        Hover(
-          contents = List(
-            RawMarkedString(language = "scala", value = tpeName)
-          ),
-          range = None
-        )
-    }
+    compiler.hover(path, position.line, position.character)
   }
 
 }

--- a/metaserver/src/main/scala/scala/meta/languageserver/compiler/HoverProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/compiler/HoverProvider.scala
@@ -26,14 +26,19 @@ object HoverProvider {
   private def typeOfTree(c: Global)(t: c.Tree): Option[String] = {
     import c._
 
-    val refinedTree = t match {
-      case t: ImplDef if t.impl != null => t.impl
-      case t: ValOrDefDef if t.tpt != null => t.tpt
-      case t: ValOrDefDef if t.rhs != null => t.rhs
-      case x => x
+    val stringOrTree = t match {
+      case t: DefDef => Right(t.symbol.asMethod.info.toLongString)
+      case t: ValDef if t.tpt != null => Left(t.tpt)
+      case t: ValDef if t.rhs != null => Left(t.rhs)
+      case x => Left(x)
     }
 
-    Option(refinedTree.tpe).map(_.toLongString)
+    stringOrTree match {
+      case Right(string) => Some(string)
+      case Left(null) => None
+      case Left(tree) => Some(tree.tpe.widen.toString)
+    }
+
   }
 
 }

--- a/metaserver/src/main/scala/scala/meta/languageserver/compiler/HoverProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/compiler/HoverProvider.scala
@@ -1,0 +1,39 @@
+package scala.meta.languageserver.compiler
+
+import scala.annotation.tailrec
+import scala.tools.nsc.interactive.Global
+import scala.reflect.internal.util.Position
+import scala.reflect.internal.util.SourceFile
+import com.typesafe.scalalogging.LazyLogging
+import langserver.messages.Hover
+import langserver.types.RawMarkedString
+
+object HoverProvider {
+  def empty: Hover = Hover(Nil, None)
+
+  def hover(compiler: Global, position: Position): Hover = {
+    val typedTree = compiler.typedTreeAt(position)
+    typeOfTree(compiler)(typedTree).fold(empty) { tpeName =>
+      Hover(
+        contents = List(
+          RawMarkedString(language = "scala", value = tpeName)
+        ),
+        range = None
+      )
+    }
+  }
+
+  private def typeOfTree(c: Global)(t: c.Tree): Option[String] = {
+    import c._
+
+    val refinedTree = t match {
+      case t: ImplDef if t.impl != null => t.impl
+      case t: ValOrDefDef if t.tpt != null => t.tpt
+      case t: ValOrDefDef if t.rhs != null => t.rhs
+      case x => x
+    }
+
+    Option(refinedTree.tpe).map(_.toLongString)
+  }
+
+}

--- a/metaserver/src/test/scala/tests/hover/HoverTest.scala
+++ b/metaserver/src/test/scala/tests/hover/HoverTest.scala
@@ -1,0 +1,106 @@
+package tests.compiler
+
+import scala.meta.languageserver.Compiler
+import scala.reflect.runtime.universe._
+import scala.reflect.runtime.currentMirror
+import scala.tools.nsc.interactive.Global
+import scala.tools.reflect.ToolBox
+
+import tests.MegaSuite
+import utest._
+
+object HoverTest extends CompilerSuite {
+
+  def check(
+      filename: String,
+      code: String,
+      expected: String
+  ): Unit = {
+    targeted(
+      filename,
+      code, { pos =>
+        val response =
+          Compiler.ask[compiler.Tree](r => compiler.askTypeAt(pos, r))
+        val typedTree = response.get.swap.toOption
+        val maybeObtained =
+          typedTree.flatMap(t => Compiler.typeOfTree(compiler)(t))
+        Predef.assert(maybeObtained.isDefined, s"No type information at ${pos}")
+        val obtained = maybeObtained.get
+        assert(obtained == expected)
+      }
+    )
+  }
+
+  check(
+    "val assignment",
+    """
+      |object a {
+      |  val <<x>> = List(Some(1), Some(2), Some(3))
+      |}
+    """.stripMargin,
+    "List[Some[Int]]"
+  )
+
+  check(
+    "val assignment type annotation",
+    """
+      |object a {
+      |  val <<x>>: List[Option[Int]] = List(Some(1), Some(2), Some(3))
+      |}
+    """.stripMargin,
+    "List[Option[Int]]"
+  )
+
+  check(
+    "select",
+    """
+      |object a {
+      |  val x = List(1, 2, 3)
+      |  <<x>>.mkString
+      |}
+    """.stripMargin,
+    "List[Int]"
+  )
+
+  check(
+    "literal Int",
+    """
+      |object a {
+      |  val x = <<42>>
+      |}
+    """.stripMargin,
+    "Int"
+  )
+
+  check(
+    "case class apply",
+    """
+      |object a {
+      |  case class User(name: String, age: Int)
+      |  val user = <<User>>("test", 42)
+      |}
+    """.stripMargin,
+    "(name: String, age: Int)a.User"
+  )
+
+  check(
+    "case class parameters",
+    """
+      |object a {
+      |  case class User(<<name>>: String, age: Int)
+      |}
+    """.stripMargin,
+    "String"
+  )
+
+  check(
+    "def",
+    """
+      |object a {
+      |  def <<test>>(x: String, y: List[Int]) = y.mkString.length
+      |}
+    """.stripMargin,
+    "(x: String, y: List[Int])Int"
+  )
+
+}

--- a/metaserver/src/test/scala/tests/hover/HoverTest.scala
+++ b/metaserver/src/test/scala/tests/hover/HoverTest.scala
@@ -47,6 +47,26 @@ object HoverTest extends CompilerSuite {
   )
 
   check(
+    "var assignment",
+    """
+      |object a {
+      |  var <<x>> = List(Some(1), Some(2), Some(3))
+      |}
+    """.stripMargin,
+    "List[Some[Int]]"
+  )
+
+  check(
+    "var assignment type annotation",
+    """
+      |object a {
+      |  var <<x>>: List[Option[Int]] = List(Some(1), Some(2), Some(3))
+      |}
+    """.stripMargin,
+    "List[Option[Int]]"
+  )
+
+  check(
     "select",
     """
       |object a {
@@ -93,6 +113,17 @@ object HoverTest extends CompilerSuite {
     """
       |object a {
       |  def <<test>>(x: String, y: List[Int]) = y.mkString.length
+      |}
+    """.stripMargin,
+    "(x: String, y: List[Int])Int"
+  )
+
+  check(
+    "def call site",
+    """
+      |object a {
+      |  def test(x: String, y: List[Int]) = y.mkString.length
+      |  <<test>>("foo", Nil)
       |}
     """.stripMargin,
     "(x: String, y: List[Int])Int"

--- a/metaserver/src/test/scala/tests/hover/HoverTest.scala
+++ b/metaserver/src/test/scala/tests/hover/HoverTest.scala
@@ -15,12 +15,13 @@ object HoverTest extends CompilerSuite {
       code, { pos =>
         val result = HoverProvider.hover(compiler, pos)
         val obtained = Json.prettyPrint(Json.toJson(result))
-        val expected = s"""{
-           |  "contents" : [ {
-           |    "language" : "scala",
-           |    "value" : "$expectedValue"
-           |  } ]
-           |}""".stripMargin
+        val expected =
+          s"""{
+             |  "contents" : [ {
+             |    "language" : "scala",
+             |    "value" : "$expectedValue"
+             |  } ]
+             |}""".stripMargin
         assertNoDiff(obtained, expected)
       }
     )


### PR DESCRIPTION
I discovered that #38 wasn't such a good idea. For some cases the "long string" isn't what we want on hover, e.g. for

```scala
val x = List(1, 2, 3)
<<x>>.mkString
```

the result is `a.x.type (with underlying type List[Int])`, whereas we would just like `List[Int]`.

In this PR I've added a few tests (built on the infrastructure of #51) that also highlight the failing cases.

I intend to fix them in this PR and I think the simplest solution is to go back to using `.tpe.widen` and maybe handling a few edge cases manually.

By the way, 👏 @olafurpg for the testing infra with chevrons: really handy to use!