### PR TITLE
Less arbitrary defaults in LanguageServer

### DIFF
--- a/languageserver/src/main/scala/langserver/core/LanguageServer.scala
+++ b/languageserver/src/main/scala/langserver/core/LanguageServer.scala
@@ -71,7 +71,6 @@ class LanguageServer(inStream: InputStream, outStream: OutputStream) extends Laz
 
   def onSaveTextDocument(td: TextDocumentIdentifier) = {
     logger.debug(s"saveTextDocument $td")
-    connection.showMessage(MessageType.Info, s"Saved text document ${td.uri}")
   }
 
   def onCloseTextDocument(td: TextDocumentIdentifier) = {
@@ -84,7 +83,7 @@ class LanguageServer(inStream: InputStream, outStream: OutputStream) extends Laz
 
   def initialize(pid: Long, rootPath: String, capabilities: ClientCapabilities): ServerCapabilities = {
     logger.debug(s"initialize with $pid, $rootPath, $capabilities")
-    ServerCapabilities(completionProvider = Some(CompletionOptions(false, Seq("."))))
+    ServerCapabilities()
   }
 
   def signatureHelpRequest(textDocument: TextDocumentIdentifier, position: Position): SignatureHelp = {

--- a/languageserver/src/main/scala/langserver/messages/Commands.scala
+++ b/languageserver/src/main/scala/langserver/messages/Commands.scala
@@ -58,7 +58,7 @@ case class ServerCapabilities(
   /**
    * The server provides completion support.
    */
-  completionProvider: Option[CompletionOptions],
+  completionProvider: Option[CompletionOptions] = None,
   /**
    * The server provides signature help support.
    */

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
@@ -256,8 +256,6 @@ class ScalametaLanguageServer(
       .getOrElse(DefinitionResult(Nil))
   }
 
-  override def onSaveTextDocument(td: TextDocumentIdentifier): Unit = {}
-
   override def signatureHelpRequest(
       td: TextDocumentIdentifier,
       position: Position


### PR DESCRIPTION
Minor changes to the default implementations in the `languageserver` bindings. They seem less arbitrary now.