### PR TITLE
Refactor the flow of effects.

### DIFF
--- a/metaserver/src/main/scala/scala/meta/languageserver/Effects.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Effects.scala
@@ -15,4 +15,6 @@ object Effects {
   final val IndexSourcesClasspath = new IndexSourcesClasspath
   final class InstallPresentationCompiler extends Effects
   final val InstallPresentationCompiler = new InstallPresentationCompiler
+  final class PublishLinterDiagnostics extends Effects
+  final val PublishLinterDiagnostics = new PublishLinterDiagnostics
 }

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
@@ -79,8 +79,8 @@ class ScalametaLanguageServer(
     compilerConfigPublisher.map(scalac.loadNewCompilerGlobals)
   val scalafixNotifications: Observable[Effects.PublishLinterDiagnostics] =
     metaSemanticdbs.map(scalafix.reportLinterMessages)
-  private var cancelEffects = Option.empty[Cancelable]
-  val effects: Observable[Effects] = Observable.merge(
+  private var cancelEffects = List.empty[Cancelable]
+  var effects: List[Observable[Effects]] = List(
     indexedDependencyClasspath,
     indexedFileSystemSemanticdbs,
     installedCompilers,
@@ -99,7 +99,7 @@ class ScalametaLanguageServer(
       capabilities: ClientCapabilities
   ): ServerCapabilities = {
     logger.info(s"Initialized with $cwd, $pid, $rootPath, $capabilities")
-    cancelEffects = Some(effects.subscribe())
+    cancelEffects = effects.map(_.subscribe())
     loadAllRelevantFilesInThisWorkspace()
     ServerCapabilities(
       completionProvider = Some(

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
@@ -80,7 +80,7 @@ class ScalametaLanguageServer(
   val scalafixNotifications: Observable[Effects.PublishLinterDiagnostics] =
     metaSemanticdbs.map(scalafix.reportLinterMessages)
   private var cancelEffects = List.empty[Cancelable]
-  var effects: List[Observable[Effects]] = List(
+  val effects: List[Observable[Effects]] = List(
     indexedDependencyClasspath,
     indexedFileSystemSemanticdbs,
     installedCompilers,

--- a/metaserver/src/main/scala/scala/meta/languageserver/search/SymbolIndex.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/search/SymbolIndex.scala
@@ -110,8 +110,7 @@ class SymbolIndex(
       DefinitionResult(location :: Nil)
     }
   }
-  // NOTE(olafur) this probably belongs somewhere else than Compiler, see
-  // https://github.com/scalameta/language-server/issues/48
+
   def indexDependencyClasspath(
       sourceJars: List[AbsolutePath]
   ): Effects.IndexSourcesClasspath = {

--- a/metaserver/src/main/scala/scala/meta/languageserver/search/SymbolIndex.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/search/SymbolIndex.scala
@@ -4,8 +4,15 @@ import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Paths
+import java.util.concurrent.ConcurrentHashMap
 import scala.meta.languageserver.Buffers
+import scala.meta.languageserver.Effects
 import scala.meta.languageserver.ScalametaEnrichments._
+import scala.meta.languageserver.ServerConfig
+import scala.meta.languageserver.compiler.CompilerConfig
+import scala.meta.languageserver.ctags.Ctags
+import scala.meta.languageserver.ScalametaLanguageServer.cacheDirectory
+import scala.meta.languageserver.storage.LevelDBMap
 import scala.meta.languageserver.{index => i}
 import `scala`.meta.languageserver.index.Position
 import `scala`.meta.languageserver.index.SymbolData
@@ -16,6 +23,7 @@ import langserver.messages.DocumentSymbolResult
 import langserver.messages.MessageType
 import org.langmeta.inputs.Input
 import org.langmeta.internal.io.FileIO
+import org.langmeta.internal.semanticdb.schema.Database
 import org.langmeta.internal.semanticdb.schema.Document
 import org.langmeta.internal.semanticdb.schema.ResolvedName
 import org.langmeta.internal.semanticdb.{schema => s}
@@ -36,7 +44,10 @@ class SymbolIndex(
     cwd: AbsolutePath,
     notifications: Notifications,
     buffers: Buffers,
+    serverConfig: ServerConfig,
 ) extends LazyLogging {
+  private val indexedJars: ConcurrentHashMap[AbsolutePath, Unit] =
+    new ConcurrentHashMap[AbsolutePath, Unit]()
 
   /** Returns a symbol at the given location with a non-empty definition */
   def findSymbol(
@@ -99,10 +110,46 @@ class SymbolIndex(
       DefinitionResult(location :: Nil)
     }
   }
+  // NOTE(olafur) this probably belongs somewhere else than Compiler, see
+  // https://github.com/scalameta/language-server/issues/48
+  def indexDependencyClasspath(
+      sourceJars: List[AbsolutePath]
+  ): Effects.IndexSourcesClasspath = {
+    if (!serverConfig.indexClasspath) Effects.IndexSourcesClasspath
+    else {
+      val sourceJarsWithJDK =
+        if (serverConfig.indexJDK)
+          CompilerConfig.jdkSources.fold(sourceJars)(_ :: sourceJars)
+        else sourceJars
+      val buf = List.newBuilder[AbsolutePath]
+      sourceJarsWithJDK.foreach { jar =>
+        // ensure we only index each jar once even under race conditions.
+        // race conditions are not unlikely since multiple .compilerconfig
+        // are typically created at the same time for each project/configuration
+        // combination. Duplicate tasks are expensive, for example we don't want
+        // to index the JDK twice on first startup.
+        indexedJars.computeIfAbsent(jar, _ => buf += jar)
+      }
+      val sourceJarsToIndex = buf.result()
+      // Acquire a lock on the leveldb cache only during indexing.
+      LevelDBMap.withDB(cacheDirectory.resolve("leveldb").toFile) { db =>
+        sourceJarsToIndex.foreach { path =>
+          logger.info(s"Indexing classpath entry $path...")
+          val database = db.getOrElseUpdate[AbsolutePath, Database](path, {
+            () =>
+              Ctags.indexDatabase(path :: Nil)
+          })
+          indexDatabase(database)
+        }
+      }
+      Effects.IndexSourcesClasspath
+    }
+  }
 
   /** Register this Database to symbol indexer. */
-  def indexDatabase(document: s.Database): Unit = {
+  def indexDatabase(document: s.Database): Effects.IndexSemanticdb = {
     document.documents.foreach(indexDocument)
+    Effects.IndexSemanticdb
   }
 
   /**
@@ -115,7 +162,7 @@ class SymbolIndex(
    *                 - filename must be a URI
    *                 - names must be sorted
    */
-  def indexDocument(document: s.Document): Unit = {
+  def indexDocument(document: s.Document): Effects.IndexSemanticdb = {
     val input = Input.VirtualFile(document.filename, document.contents)
     // what do we put as the uri?
     val uri = URI.create(document.filename)
@@ -147,6 +194,7 @@ class SymbolIndex(
         symbols.addDenotation(sym, denot.flags, denot.name, denot.signature)
       case _ =>
     }
+    Effects.IndexSemanticdb
   }
 
   /**
@@ -250,16 +298,24 @@ class SymbolIndex(
 object SymbolIndex {
 
   def empty(cwd: AbsolutePath): SymbolIndex =
-    apply(cwd, (_, _) => (), Buffers())
+    apply(cwd, (_, _) => (), Buffers(), ServerConfig(cwd))
 
   def apply(
       cwd: AbsolutePath,
       notifications: Notifications,
-      buffers: Buffers
+      buffers: Buffers,
+      serverConfig: ServerConfig
   ): SymbolIndex = {
     val symbols = new TrieMapSymbolIndexer()
     val documents = new InMemoryDocumentIndex()
-    new SymbolIndex(symbols, documents, cwd, notifications, buffers)
+    new SymbolIndex(
+      symbols,
+      documents,
+      cwd,
+      notifications,
+      buffers,
+      serverConfig
+    )
   }
 
 }

--- a/metaserver/src/test/scala/tests/search/SymbolIndexTest.scala
+++ b/metaserver/src/test/scala/tests/search/SymbolIndexTest.scala
@@ -54,7 +54,10 @@ object SymbolIndexTest extends MegaSuite {
         expected: String
     ): Unit = {
       val term = indexer.findSymbol(path, line, column)
-      Predef.assert(term.isDefined, s"Symbol not found at $path:$line:$column")
+      Predef.assert(
+        term.isDefined,
+        s"Symbol not found at $path:$line:$column. Did you run scalametaEnableCompletions from sbt?"
+      )
       assertNoDiff(term.get.symbol, expected)
       Predef.assert(
         term.get.definition.isDefined,


### PR DESCRIPTION
This commit reorganizes the flow of effects in the application. Most
notably,

- scalac provider no longer handles indexing of classpath sources,
  SymbolIndex handles all indexing.
- Observable[Effect] no longer leak into utilities like
  Scalafix/ScalacProvider, these stay only within ScalametaLanguageServer.