### PR TITLE
s/ctags/mtags/

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ To run these tests,
 ```
 sbt
 > metaserver/test                     # Run all unit tests
-> metaserver/testOnly -- tests.ctags  # Only test the ctags tests
+> metaserver/testOnly -- tests.mtags  # Only test the mtags tests
 > metaserver/testOnly -- tests.search # Only test the symbol indexer tests
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -102,7 +102,7 @@ lazy val metaserver = project
       "org.fusesource.leveldbjni" % "leveldbjni-all" % "1.8",
       "io.monix" %% "monix" % "2.3.0",
       "com.lihaoyi" %% "pprint" % "0.5.3",
-      "com.thoughtworks.qdox" % "qdox" % "2.0-M7", // for java ctags
+      "com.thoughtworks.qdox" % "qdox" % "2.0-M7", // for java mtags
       "io.get-coursier" %% "coursier" % coursier.util.Properties.version,
       "io.get-coursier" %% "coursier-cache" % coursier.util.Properties.version,
       "ch.epfl.scala" % "scalafix-cli" % "0.5.6" cross CrossVersion.full,

--- a/metaserver/src/main/scala/scala/meta/languageserver/mtags/JavaMtags.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/mtags/JavaMtags.scala
@@ -1,4 +1,4 @@
-package scala.meta.languageserver.ctags
+package scala.meta.languageserver.mtags
 
 import java.io.StringReader
 import scala.meta.CLASS
@@ -19,13 +19,13 @@ import org.langmeta.inputs.Input
 import org.langmeta.inputs.Position
 import org.langmeta.languageserver.InputEnrichments._
 
-object JavaCtags {
+object JavaMtags {
   private implicit class XtensionJavaModel(val m: JavaModel) extends AnyVal {
     def lineNumber: Int = m.getLineNumber - 1
   }
-  def index(input: Input.VirtualFile): CtagsIndexer = {
+  def index(input: Input.VirtualFile): MtagsIndexer = {
     val builder = new JavaProjectBuilder()
-    new CtagsIndexer { self =>
+    new MtagsIndexer { self =>
       override def indexRoot(): Unit = {
         try {
           val source = builder.addSource(new StringReader(input.value))

--- a/metaserver/src/main/scala/scala/meta/languageserver/mtags/Mtags.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/mtags/Mtags.scala
@@ -1,4 +1,4 @@
-package scala.meta.languageserver.ctags
+package scala.meta.languageserver.mtags
 
 import java.io.IOException
 import java.net.URI
@@ -38,9 +38,10 @@ import org.langmeta.internal.semanticdb.schema.Document
  * requiring dependencies to publish semanticdbs alongside their artifacts.
  *
  * One other use-case for this module is to implement "Workspace symbol provider"
- * without any build-tool or compiler integration. Essentially, ctags.
+ * without any build-tool or compiler integration. "Mtags" name comes from
+ * mixing "meta" and "ctags".
  */
-object Ctags extends LazyLogging {
+object Mtags extends LazyLogging {
 
   /**
    * Build an index from a classpath of -sources.jar
@@ -137,9 +138,9 @@ object Ctags extends LazyLogging {
   /** Index single Scala or Java source file from memory */
   def index(input: Input.VirtualFile): Document = {
     logger.trace(s"Indexing ${input.path} with length ${input.value.length}")
-    val indexer: CtagsIndexer =
-      if (isScala(input.path)) ScalaCtags.index(input)
-      else if (isJava(input.path)) JavaCtags.index(input)
+    val indexer: MtagsIndexer =
+      if (isScala(input.path)) ScalaMtags.index(input)
+      else if (isJava(input.path)) JavaMtags.index(input)
       else {
         throw new IllegalArgumentException(
           s"Unknown file extension ${input.path}"

--- a/metaserver/src/main/scala/scala/meta/languageserver/mtags/MtagsIndexer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/mtags/MtagsIndexer.scala
@@ -1,4 +1,4 @@
-package scala.meta.languageserver.ctags
+package scala.meta.languageserver.mtags
 
 import scala.meta.Name
 import scala.meta.Term
@@ -13,7 +13,7 @@ import org.{langmeta => m}
 import org.langmeta.semanticdb.Signature
 import org.langmeta.semanticdb.Symbol
 
-trait CtagsIndexer {
+trait MtagsIndexer {
   def language: String
   def indexRoot(): Unit
   def index(): (List[ResolvedName], List[ResolvedSymbol]) = {

--- a/metaserver/src/main/scala/scala/meta/languageserver/mtags/ScalaMtags.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/mtags/ScalaMtags.scala
@@ -1,12 +1,12 @@
-package scala.meta.languageserver.ctags
+package scala.meta.languageserver.mtags
 
 import scala.meta._
 import org.langmeta.inputs.Input
 
-object ScalaCtags {
-  def index(input: Input.VirtualFile): CtagsIndexer = {
+object ScalaMtags {
+  def index(input: Input.VirtualFile): MtagsIndexer = {
     val root: Source = input.parse[Source].get
-    new Traverser with CtagsIndexer {
+    new Traverser with MtagsIndexer {
       override def language: String =
         "Scala212" // TODO(olafur) more accurate dialect
       override def indexRoot(): Unit = apply(root)

--- a/metaserver/src/main/scala/scala/meta/languageserver/search/SymbolIndex.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/search/SymbolIndex.scala
@@ -10,7 +10,7 @@ import scala.meta.languageserver.Effects
 import scala.meta.languageserver.ScalametaEnrichments._
 import scala.meta.languageserver.ServerConfig
 import scala.meta.languageserver.compiler.CompilerConfig
-import scala.meta.languageserver.ctags.Ctags
+import scala.meta.languageserver.mtags.Mtags
 import scala.meta.languageserver.ScalametaLanguageServer.cacheDirectory
 import scala.meta.languageserver.storage.LevelDBMap
 import scala.meta.languageserver.{index => i}
@@ -136,7 +136,7 @@ class SymbolIndex(
           logger.info(s"Indexing classpath entry $path...")
           val database = db.getOrElseUpdate[AbsolutePath, Database](path, {
             () =>
-              Ctags.indexDatabase(path :: Nil)
+              Mtags.indexDatabase(path :: Nil)
           })
           indexDatabase(database)
         }

--- a/metaserver/src/test/scala/tests/mtags/BaseMtagsTest.scala
+++ b/metaserver/src/test/scala/tests/mtags/BaseMtagsTest.scala
@@ -1,10 +1,10 @@
-package tests.ctags
+package tests.mtags
 
-import scala.meta.languageserver.ctags.Ctags
+import scala.meta.languageserver.mtags.Mtags
 import org.langmeta.internal.semanticdb.schema.Database
 import tests.MegaSuite
 
-class BaseCtagsTest extends MegaSuite {
+class BaseMtagsTest extends MegaSuite {
   def checkIgnore(
       filename: String,
       original: String,
@@ -14,7 +14,7 @@ class BaseCtagsTest extends MegaSuite {
   }
   def check(filename: String, original: String, expected: String): Unit = {
     test(filename) {
-      val obtained = Database(Ctags.index(filename, original) :: Nil)
+      val obtained = Database(Mtags.index(filename, original) :: Nil)
 //      println(obtained)
       assertNoDiff(obtained.toDb(None).documents.head.syntax, expected)
     }

--- a/metaserver/src/test/scala/tests/mtags/ClasspathMtagsTest.scala
+++ b/metaserver/src/test/scala/tests/mtags/ClasspathMtagsTest.scala
@@ -1,12 +1,12 @@
-package tests.ctags
+package tests.mtags
 
 import java.nio.file.Paths
 import scala.meta.languageserver.Jars
-import scala.meta.languageserver.ctags.Ctags
+import scala.meta.languageserver.mtags.Mtags
 import org.langmeta.internal.semanticdb.schema.Database
 import tests.MegaSuite
 
-object ClasspathCtagsTest extends MegaSuite {
+object ClasspathMtagsTest extends MegaSuite {
 
   // NOTE(olafur) this test is a bit slow since it downloads jars from the internet.
   ignore("index classpath") {
@@ -22,7 +22,7 @@ object ClasspathCtagsTest extends MegaSuite {
     val Predef = Paths.get("scala").resolve("io").resolve("AnsiColor.scala")
     val CharRef = Paths.get("scala").resolve("runtime").resolve("CharRef.java")
     val docs = List.newBuilder[String]
-    Ctags.index(
+    Mtags.index(
       classpath,
       shouldIndex = { path =>
         path.toNIO.endsWith(CharRef) ||

--- a/metaserver/src/test/scala/tests/mtags/JavaMtagsTest.scala
+++ b/metaserver/src/test/scala/tests/mtags/JavaMtagsTest.scala
@@ -1,10 +1,10 @@
-package tests.ctags
+package tests.mtags
 
 import java.nio.file.Paths
 import scala.meta.languageserver.compiler.CompilerConfig
-import scala.meta.languageserver.ctags.Ctags
+import scala.meta.languageserver.mtags.Mtags
 
-object JavaCtagsTest extends BaseCtagsTest {
+object JavaMtagsTest extends BaseMtagsTest {
   check(
     "interface.java",
     """package a.b;
@@ -127,7 +127,7 @@ object JavaCtagsTest extends BaseCtagsTest {
 //  }
 //  }}}
 //  from Flexmark where EMPTY_SET is static but doesn't have isStatic = true.
-// JavaCtags currently marks it as Extension#EMPTY_SET but scalac sees it as Extension.EMPTY_SET
+// JavaMtags currently marks it as Extension#EMPTY_SET but scalac sees it as Extension.EMPTY_SET
   checkIgnore(
     "default.java",
     """package k;
@@ -157,7 +157,7 @@ object JavaCtagsTest extends BaseCtagsTest {
     val jdk = CompilerConfig.jdkSources.get
     val DefaultFileSystem =
       Paths.get("java").resolve("io").resolve("DefaultFileSystem.java")
-    val db = Ctags.indexDatabase(jdk :: Nil, shouldIndex = { path =>
+    val db = Mtags.indexDatabase(jdk :: Nil, shouldIndex = { path =>
       path.toNIO.endsWith(DefaultFileSystem)
     })
     val obtained = db
@@ -191,7 +191,7 @@ object JavaCtagsTest extends BaseCtagsTest {
 
   // Ignored because it's slow
   ignore("index JDK") {
-    val db = Ctags.indexDatabase(CompilerConfig.jdkSources.get :: Nil)
+    val db = Mtags.indexDatabase(CompilerConfig.jdkSources.get :: Nil)
     pprint.log(db.documents.length)
   }
 }

--- a/metaserver/src/test/scala/tests/mtags/ScalaMtagsTest.scala
+++ b/metaserver/src/test/scala/tests/mtags/ScalaMtagsTest.scala
@@ -1,6 +1,6 @@
-package tests.ctags
+package tests.mtags
 
-object ScalaCtagsTest extends BaseCtagsTest {
+object ScalaMtagsTest extends BaseMtagsTest {
   check(
     "vanilla.scala",
     """

--- a/metaserver/src/test/scala/tests/search/SymbolIndexTest.scala
+++ b/metaserver/src/test/scala/tests/search/SymbolIndexTest.scala
@@ -77,9 +77,9 @@ object SymbolIndexTest extends MegaSuite {
     }
 
     "classpath" - {
-      "<<List>>(...)" - // ScalaCtags
+      "<<List>>(...)" - // ScalaMtags
         assertSymbolFound(5, 5, "_root_.scala.collection.immutable.List.")
-      "<<CharRef>>.create(...)" - // JavaCtags
+      "<<CharRef>>.create(...)" - // JavaMtags
         assertSymbolFound(8, 19, "_root_.scala.runtime.CharRef.")
     }
 


### PR DESCRIPTION
Based on feedback it seems the "ctags" name was confusing since (not
surprisingly) many thought it actually produce ctags indicies. The Mtags
module produces scalameta semanticdb indices syntactically, similarly
to how ctags indicies are build. mtags indices however contain more
information like flags to distinguish object/trait/class/def