### PR TITLE
Updated sbt and plugins

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.0.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
-addSbtPlugin("ch.epfl.scala" % "sbt-release-early" % "1.2.0")
+addSbtPlugin("ch.epfl.scala" % "sbt-release-early" % "2.0.0")
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC13")
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
 addSbtPlugin(
-  "com.thesamet" % "sbt-protoc" % "0.99.12" exclude ("com.trueaccord.scalapb", "protoc-bridge_2.10")
+  "com.thesamet" % "sbt-protoc" % "0.99.13" exclude ("com.trueaccord.scalapb", "protoc-bridge_2.12")
 )
 libraryDependencies += "com.trueaccord.scalapb" %% "compilerplugin-shaded" % "0.6.6"


### PR DESCRIPTION
sbt 1.0.4 has been [released recently](https://developer.lightbend.com/blog/2017-11-27-sbt-1-0-4-hotfix-and-performance-fixes/index.html) and is supposed to fix the continuous compilation problem. 