### PR TITLE
Symbols outline rework

### DIFF
--- a/metaserver/src/main/scala/scala/meta/languageserver/Buffers.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Buffers.scala
@@ -31,8 +31,10 @@ class Buffers private (
   }
   def changed(path: AbsolutePath, newContents: String): Unit =
     contents.put(path, newContents)
-  def closed(path: AbsolutePath): Unit =
+  def closed(path: AbsolutePath): Unit = {
+    contents.remove(path)
     sources.remove(path)
+  }
 
   def read(td: TextDocumentIdentifier): String =
     read(URI.create(td.uri))

--- a/metaserver/src/main/scala/scala/meta/languageserver/Buffers.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Buffers.scala
@@ -9,7 +9,7 @@ import com.typesafe.scalalogging.LazyLogging
 import langserver.types.TextDocumentIdentifier
 import org.langmeta.io.AbsolutePath
 import org.langmeta.io.RelativePath
-import scala.meta._
+import scala.meta.Source
 
 /**
  * Utility to keep local state of file contents.
@@ -43,8 +43,8 @@ class Buffers private (
   private val sources: JMap[AbsolutePath, Source] = new ConcurrentHashMap()
   // Tries to parse and record it or fallback to an old source if it existed
   def source(path: AbsolutePath): Option[Source] =
-    read(path)
-      .parse[Source]
+    Parser
+      .parse(read(path))
       .toOption
       .map { tree =>
         sources.put(path, tree)

--- a/metaserver/src/main/scala/scala/meta/languageserver/Buffers.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Buffers.scala
@@ -31,6 +31,9 @@ class Buffers private (
   }
   def changed(path: AbsolutePath, newContents: String): Unit =
     contents.put(path, newContents)
+  def closed(path: AbsolutePath): Unit =
+    sources.remove(path)
+
   def read(td: TextDocumentIdentifier): String =
     read(URI.create(td.uri))
   def read(uri: URI): String =

--- a/metaserver/src/main/scala/scala/meta/languageserver/OutlineProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/OutlineProvider.scala
@@ -57,11 +57,8 @@ object OutlineProvider extends LazyLogging {
   }
 
   def documentSymbols(
-      buffers: Buffers,
-      path: AbsolutePath
-  ): List[l.SymbolInformation] = {
-    buffers.read(path).parse[Source].toOption.toList.flatMap { tree =>
-      new OutlineTraverser(path).apply(tree)
-    }
-  }
+      path: AbsolutePath,
+      source: Source
+  ): List[l.SymbolInformation] =
+    new OutlineTraverser(path).apply(source)
 }

--- a/metaserver/src/main/scala/scala/meta/languageserver/OutlineProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/OutlineProvider.scala
@@ -1,0 +1,67 @@
+package scala.meta.languageserver
+
+import scala.collection.mutable
+import com.typesafe.scalalogging.LazyLogging
+import org.langmeta.io.AbsolutePath
+import langserver.{types => l}
+import langserver.messages.DefinitionResult
+import scala.meta.languageserver.ScalametaEnrichments._
+import scala.meta._
+
+object OutlineProvider extends LazyLogging {
+
+  private class OutlineTraverser(path: AbsolutePath) {
+    private val builder = List.newBuilder[l.SymbolInformation]
+
+    val traverser = new Traverser {
+      private var currentRoot: Option[Tree] = None
+      override def apply(currentNode: Tree): Unit = {
+        def continue(withNewRoot: Boolean = false): Unit = {
+          val oldRoot = currentRoot
+          if (withNewRoot) currentRoot = Some(currentNode)
+          super.apply(currentNode)
+          currentRoot = oldRoot
+        }
+
+        def addName(name: String): Unit = {
+          builder += l.SymbolInformation(
+            name = name,
+            kind = currentNode.symbolKind,
+            location = path.toLocation(currentNode.pos),
+            containerName = currentRoot.flatMap(_.qualifiedName)
+          )
+        }
+
+        def addNode(): Unit = currentNode.names.foreach(addName)
+
+        currentNode match {
+          // we need to go deeper
+          case Source(_) | Template(_) => continue()
+          // add package, but don't set it as a new root
+          case Pkg(_) => addNode(); continue()
+          // terminal nodes: add them, but don't go inside
+          case Defn.Def(_) | Defn.Val(_) | Defn.Var(_) => addNode()
+          case Decl.Def(_) | Decl.Val(_) | Decl.Var(_) => addNode()
+          // all other (named) types and terms can contain more nodes
+          case t if t.is[Member.Type] || t.is[Member.Term] =>
+            addNode(); continue(withNewRoot = true)
+          case _ => ()
+        }
+      }
+    }
+
+    def apply(tree: Tree): List[l.SymbolInformation] = {
+      traverser.apply(tree)
+      builder.result()
+    }
+  }
+
+  def documentSymbols(
+      buffers: Buffers,
+      path: AbsolutePath
+  ): List[l.SymbolInformation] = {
+    buffers.read(path).parse[Source].toOption.toList.flatMap { tree =>
+      new OutlineTraverser(path).apply(tree)
+    }
+  }
+}

--- a/metaserver/src/main/scala/scala/meta/languageserver/Parser.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Parser.scala
@@ -5,6 +5,7 @@ import scala.meta.Source
 import scala.meta.parsers.Parsed
 import org.langmeta.inputs.Position
 import org.langmeta.semanticdb.Document
+import scalafix.internal.config.ScalafixConfig
 
 // Small utility to parse inputs into scala.meta.Tree,
 // this is missing in the API after semanticdb went language agnostics with langmeta.
@@ -18,4 +19,6 @@ object Parser {
         Parsed.Error(Position.None, err, new IllegalArgumentException(err))
     }
 
+  def parse(content: String): Parsed[Source] =
+    ScalafixConfig.DefaultDialect(content).parse[Source]
 }

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaEnrichments.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaEnrichments.scala
@@ -70,12 +70,14 @@ object ScalametaEnrichments {
      * - if it's a val/var, it may contain several names in the pattern: `val (x, y, z) = ...`
      * - for everything else it's just its normal name (if it has one)
      */
+    private def patternNames(pats: List[Pat]): Seq[String] =
+      pats.flatMap { _.collect { case Pat.Var(name) => name.value } }
     def names: Seq[String] = tree match {
       case t: Pkg => t.qualifiedName.toSeq
-      case t: Defn.Val => t.pats.collect { case Pat.Var(name) => name.value }
-      case t: Decl.Val => t.pats.collect { case Pat.Var(name) => name.value }
-      case t: Defn.Var => t.pats.collect { case Pat.Var(name) => name.value }
-      case t: Decl.Var => t.pats.collect { case Pat.Var(name) => name.value }
+      case t: Defn.Val => patternNames(t.pats)
+      case t: Decl.Val => patternNames(t.pats)
+      case t: Defn.Var => patternNames(t.pats)
+      case t: Decl.Var => patternNames(t.pats)
       case t: Member => Seq(t.name.value)
       case _ => Seq()
     }

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
@@ -189,11 +189,13 @@ class ScalametaLanguageServer(
 
   override def documentSymbols(
       td: TextDocumentIdentifier
-  ): List[SymbolInformation] =
-    OutlineProvider.documentSymbols(
-      buffers,
-      Uri.toPath(td.uri).get
-    )
+  ): List[SymbolInformation] = {
+    val path = Uri.toPath(td.uri).get
+    buffers.source(path) match {
+      case Some(source) => OutlineProvider.documentSymbols(path, source)
+      case None => Nil
+    }
+  }
 
   override def gotoDefinitionRequest(
       td: TextDocumentIdentifier,

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
@@ -15,6 +15,7 @@ import scala.meta.languageserver.compiler.SignatureHelpProvider
 import scala.meta.languageserver.search.SymbolIndex
 import scala.meta.languageserver.search.DefinitionProvider
 import scala.meta.languageserver.search.ReferencesProvider
+import scala.meta.languageserver.providers._
 import scalafix.internal.util.EagerInMemorySemanticdbIndex
 import com.typesafe.scalalogging.LazyLogging
 import io.github.soc.directories.ProjectDirectories
@@ -192,7 +193,7 @@ class ScalametaLanguageServer(
   ): List[SymbolInformation] = {
     val path = Uri.toPath(td.uri).get
     buffers.source(path) match {
-      case Some(source) => OutlineProvider.documentSymbols(path, source)
+      case Some(source) => DocumentSymbolProvider.documentSymbols(path, source)
       case None => Nil
     }
   }

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
@@ -188,6 +188,9 @@ class ScalametaLanguageServer(
     }
   }
 
+  override def onCloseTextDocument(td: TextDocumentIdentifier): Unit =
+    Uri.toPath(td.uri).foreach(buffers.closed)
+
   override def documentSymbols(
       td: TextDocumentIdentifier
   ): List[SymbolInformation] = {

--- a/metaserver/src/main/scala/scala/meta/languageserver/providers/DocumentSymbolProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/providers/DocumentSymbolProvider.scala
@@ -1,4 +1,4 @@
-package scala.meta.languageserver
+package scala.meta.languageserver.providers
 
 import scala.collection.mutable
 import com.typesafe.scalalogging.LazyLogging
@@ -8,9 +8,9 @@ import langserver.messages.DefinitionResult
 import scala.meta.languageserver.ScalametaEnrichments._
 import scala.meta._
 
-object OutlineProvider extends LazyLogging {
+object DocumentSymbolProvider extends LazyLogging {
 
-  private class OutlineTraverser(path: AbsolutePath) {
+  private class SymbolTraverser(path: AbsolutePath) {
     private val builder = List.newBuilder[l.SymbolInformation]
 
     val traverser = new Traverser {
@@ -60,5 +60,5 @@ object OutlineProvider extends LazyLogging {
       path: AbsolutePath,
       source: Source
   ): List[l.SymbolInformation] =
-    new OutlineTraverser(path).apply(source)
+    new SymbolTraverser(path).apply(source)
 }


### PR DESCRIPTION
This is a follow-up of #34. Previous PR was OK as a first try, but had a lot of problems:
* listing symbols inside of defs, vals and vars (and misplacing their children)
* used ineffective traversal: collecting all named nodes and then trying to get up their lineage with different conditions (what seemed to me as a light and smart solution at first, was actually clumsy and bug-prone)
* while the buffer was in unparseable state, outline became empty

This PR solves all these problems (and hopefully doesn't introduce new ones):
* outline provider is implemented using `Traverser`
* parsed `Source`s are stored and old ones are reused while buffer is not parseable

It seems to work well, but I have a couple of doubts about code organization:
* where should I put `OutlineProvider`? is it ok in the "root" package?
* probably `Buffers` is not the best place for storing those parsed `Source`s
* if it was somewhere "closer" to the `OutlineProvider` itself, it would make more sense to store outlines, so that we don't traverse old trees on each request while the buffer is being edited