### PR TITLE
First take on textDocument/documentHighlight

### DIFF
--- a/languageserver/src/main/scala/langserver/core/LanguageServer.scala
+++ b/languageserver/src/main/scala/langserver/core/LanguageServer.scala
@@ -25,6 +25,8 @@ class LanguageServer(inStream: InputStream, outStream: OutputStream) extends Laz
         gotoDefinitionRequest(textDocument, position)
       case ("textDocument/references", TextDocumentReferencesRequest(ReferenceParams(textDocument, position, context))) =>
         referencesRequest(textDocument, position, context)
+      case ("textDocument/documentHighlight", TextDocumentDocumentHighlightRequest(TextDocumentPositionParams(textDocument, position))) =>
+        documentHighlightRequest(textDocument, position)
       case ("textDocument/hover", TextDocumentHoverRequest(TextDocumentPositionParams(textDocument, position))) =>
         hoverRequest(textDocument, position)
       case ("textDocument/documentSymbol", DocumentSymbolParams(tdi)) =>
@@ -104,6 +106,10 @@ class LanguageServer(inStream: InputStream, outStream: OutputStream) extends Laz
 
   def referencesRequest(textDocument: TextDocumentIdentifier, position: Position, context: ReferenceContext): ReferencesResult = {
     ReferencesResult(Seq.empty[Location])
+  }
+
+  def documentHighlightRequest(textDocument: TextDocumentIdentifier, position: Position): DocumentHighlightResult = {
+    DocumentHighlightResult(Seq.empty[Location])
   }
 
   def hoverRequest(textDocument: TextDocumentIdentifier, position: Position): Hover = {

--- a/languageserver/src/main/scala/langserver/messages/Commands.scala
+++ b/languageserver/src/main/scala/langserver/messages/Commands.scala
@@ -188,6 +188,7 @@ case class TextDocumentSignatureHelpRequest(params: TextDocumentPositionParams) 
 case class TextDocumentCompletionRequest(params: TextDocumentPositionParams) extends ServerCommand
 case class TextDocumentDefinitionRequest(params: TextDocumentPositionParams) extends ServerCommand
 case class TextDocumentReferencesRequest(params: ReferenceParams) extends ServerCommand
+case class TextDocumentDocumentHighlightRequest(params: TextDocumentPositionParams) extends ServerCommand
 case class TextDocumentHoverRequest(params: TextDocumentPositionParams) extends ServerCommand
 case class TextDocumentFormattingRequest(params: DocumentFormattingParams) extends ServerCommand
 
@@ -208,6 +209,7 @@ object ServerCommand extends CommandCompanion[ServerCommand] {
     "textDocument/signatureHelp" -> valueFormat(TextDocumentSignatureHelpRequest)(_.params),
     "textDocument/definition" -> valueFormat(TextDocumentDefinitionRequest)(_.params),
     "textDocument/references" -> valueFormat(TextDocumentReferencesRequest)(_.params),
+    "textDocument/documentHighlight" -> valueFormat(TextDocumentDocumentHighlightRequest)(_.params),
     "textDocument/hover" -> valueFormat(TextDocumentHoverRequest)(_.params),
     "textDocument/documentSymbol" -> Json.format[DocumentSymbolParams],
     "textDocument/formatting" -> valueFormat(TextDocumentFormattingRequest)(_.params)
@@ -284,6 +286,7 @@ object Notification extends NotificationCompanion[Notification] {
 case class DocumentSymbolResult(params: Seq[SymbolInformation]) extends ResultResponse
 case class DefinitionResult(params: Seq[Location]) extends ResultResponse
 case class ReferencesResult(params: Seq[Location]) extends ResultResponse
+case class DocumentHighlightResult(params: Seq[Location]) extends ResultResponse
 case class DocumentFormattingResult(params: Seq[TextEdit]) extends ResultResponse
 
 object ResultResponse extends ResponseCompanion[Any] {
@@ -295,6 +298,7 @@ object ResultResponse extends ResponseCompanion[Any] {
     "textDocument/signatureHelp" -> Json.format[SignatureHelp],
     "textDocument/definition" -> valueFormat(DefinitionResult)(_.params),
     "textDocument/references" -> valueFormat(ReferencesResult)(_.params),
+    "textDocument/documentHighlight" -> valueFormat(DocumentHighlightResult)(_.params),
     "textDocument/hover" -> Json.format[Hover],
     "textDocument/documentSymbol" -> valueFormat(DocumentSymbolResult)(_.params),
     "textDocument/formatting" -> valueFormat(DocumentFormattingResult)(_.params),

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaEnrichments.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaEnrichments.scala
@@ -98,7 +98,7 @@ object ScalametaEnrichments {
   }
   implicit class XtensionIndexRange(val range: i.Range) extends AnyVal {
     def pretty: String =
-      f"${range.startLine}%2d:${range.startColumn}%2d|${range.endLine}%2d:${range.endColumn}%2d"
+      f"${range.startLine}%3d:${range.startColumn}%3d|${range.endLine}%3d:${range.endColumn}%3d"
     def toRange: l.Range = l.Range(
       l.Position(line = range.startLine, character = range.startColumn),
       l.Position(line = range.endLine, character = range.endColumn)

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
@@ -24,6 +24,7 @@ import langserver.messages.ClientCapabilities
 import langserver.messages.CompletionOptions
 import langserver.messages.DefinitionResult
 import langserver.messages.ReferencesResult
+import langserver.messages.DocumentHighlightResult
 import langserver.messages.Hover
 import langserver.messages.ResultResponse
 import langserver.messages.ServerCapabilities
@@ -118,6 +119,7 @@ class ScalametaLanguageServer(
       ),
       definitionProvider = true,
       referencesProvider = true,
+      documentHighlightProvider = true,
       documentSymbolProvider = true,
       documentFormattingProvider = true,
       hoverProvider = true
@@ -222,6 +224,16 @@ class ScalametaLanguageServer(
       Uri.toPath(td.uri).get,
       position,
       context
+    )
+
+  override def documentHighlightRequest(
+      td: TextDocumentIdentifier,
+      position: Position
+  ): DocumentHighlightResult =
+    DocumentHighlightProvider.highlight(
+      symbolIndex,
+      Uri.toPath(td.uri).get,
+      position
     )
 
   override def signatureHelpRequest(

--- a/metaserver/src/main/scala/scala/meta/languageserver/providers/DocumentHighlightProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/providers/DocumentHighlightProvider.scala
@@ -1,0 +1,33 @@
+package scala.meta.languageserver.providers
+
+import com.typesafe.scalalogging.LazyLogging
+import org.langmeta.io.AbsolutePath
+import langserver.{types => l}
+import langserver.messages.DocumentHighlightResult
+import scala.meta.languageserver.Uri
+import scala.meta.languageserver.search.SymbolIndex
+import scala.meta.languageserver.ScalametaEnrichments._
+
+object DocumentHighlightProvider extends LazyLogging {
+
+  def highlight(
+      symbolIndex: SymbolIndex,
+      path: AbsolutePath,
+      position: l.Position
+  ): DocumentHighlightResult = {
+    logger.info(s"Document highlight in ${path}")
+    val locations = for {
+      name <- symbolIndex
+        .resolveName(path, position.line, position.character)
+        .toList
+      data <- symbolIndex.symbolIndexer.get(name.symbol).toList
+      _ = logger.info(s"Highlighting symbol `${data.name}: ${data.signature}`")
+      pos <- data.referencePositions(withDefinition = true)
+      if Uri.toPath(pos.uri) == Some(path)
+      _ = logger.debug(s"Found highlight at [${pos.range.get.pretty}]")
+    } yield pos.toLocation
+    // TODO(alexey) add DocumentHighlightKind: Text (default), Read, Write
+    DocumentHighlightResult(locations)
+  }
+
+}


### PR DESCRIPTION
This is a draft implementation of the [`textDocument/documentHighlight`](https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#document-highlights-request) request. It's based on the #78 (references). Highlights are basically local references, but LSP spec is not very clear on it:

> For programming languages this usually highlights all references to the symbol scoped to this file. However we kept 'textDocument/documentHighlight' and 'textDocument/references' separate requests since the first one is allowed to be more _fuzzy_.

So let's keep it _fuzzy_ 🖖

Here's a little demo showing how it works and how it's a bit _too fuzzy_ sometimes:

![2017-12-05 03 45 55](https://user-images.githubusercontent.com/766656/33587821-2d0c300e-d970-11e7-9e78-8def9ca5a608.gif)

You can see that `data` and `pos` are highlighted inconsistently. I didn't investigate yet why it happens and whether it's a general problem with indexing/references.

----

Another missing feature (out of the scope for this PR) is `DocumentHighlightKind`:

> Symbol matches usually have a `DocumentHighlightKind` of `Read` or `Write` whereas fuzzy or textual matches use `Text` as the kind.

* `Text`: A textual occurrence
* `Read`: Read-access of a symbol, like reading a variable.
* `Write`: Write-access of a symbol, like writing to a variable.

I even doubt editors support those kinds yet.