### PR TITLE
Produce a stream of semanticdbs as you type

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -113,8 +113,9 @@ lazy val metaserver = project
       "io.get-coursier" %% "coursier" % coursier.util.Properties.version,
       "io.get-coursier" %% "coursier-cache" % coursier.util.Properties.version,
       "ch.epfl.scala" % "scalafix-cli" % "0.5.7" cross CrossVersion.full,
+      "org.scalameta" %% "semanticdb-scalac" % V.scalameta cross CrossVersion.full,
       "com.lihaoyi" %% "utest" % "0.6.0" % Test,
-      "org.scalameta" %% "testkit" % V.scalameta % Test
+      "org.scalameta" %% "testkit" % V.scalameta % Test,
     )
   )
   .dependsOn(

--- a/metaserver/src/main/scala/scala/meta/languageserver/Buffers.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Buffers.scala
@@ -7,6 +7,7 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.{Map => JMap}
 import com.typesafe.scalalogging.LazyLogging
 import langserver.types.TextDocumentIdentifier
+import langserver.types.VersionedTextDocumentIdentifier
 import org.langmeta.io.AbsolutePath
 import org.langmeta.io.RelativePath
 import scala.meta.Source
@@ -37,6 +38,8 @@ class Buffers private (
   }
 
   def read(td: TextDocumentIdentifier): String =
+    read(URI.create(td.uri))
+  def read(td: VersionedTextDocumentIdentifier): String =
     read(URI.create(td.uri))
   def read(uri: URI): String =
     read(AbsolutePath(uri.getPath))

--- a/metaserver/src/main/scala/scala/meta/languageserver/Effects.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Effects.scala
@@ -17,4 +17,6 @@ object Effects {
   final val InstallPresentationCompiler = new InstallPresentationCompiler
   final class PublishLinterDiagnostics extends Effects
   final val PublishLinterDiagnostics = new PublishLinterDiagnostics
+  final class PublishScalacDiagnostics extends Effects
+  final val PublishScalacDiagnostics = new PublishScalacDiagnostics
 }

--- a/metaserver/src/main/scala/scala/meta/languageserver/ErrorReporter.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ErrorReporter.scala
@@ -1,0 +1,49 @@
+package scala.meta.languageserver
+
+import scala.meta.languageserver.ScalametaEnrichments._
+import scala.{meta => m}
+import scala.meta.semanticdb
+import scalafix.internal.util.EagerInMemorySemanticdbIndex
+import scalafix.util.SemanticdbIndex
+import langserver.core.Connection
+import langserver.messages.PublishDiagnostics
+import langserver.{types => l}
+
+class ScalacErrorReporter(
+    connection: Connection,
+) {
+
+  def reportErrors(
+      mdb: m.Database
+  ): Effects.PublishScalacDiagnostics = {
+    val messages = analyzeIndex(mdb)
+    messages.foreach(connection.sendNotification)
+    Effects.PublishScalacDiagnostics
+  }
+  private def analyzeIndex(mdb: m.Database): Seq[PublishDiagnostics] =
+    analyzeIndex(
+      EagerInMemorySemanticdbIndex(mdb, m.Sourcepath(Nil), m.Classpath(Nil))
+    )
+  private def analyzeIndex(index: SemanticdbIndex): Seq[PublishDiagnostics] =
+    index.database.documents.map { d =>
+      val uri = d.input.syntax
+      PublishDiagnostics(uri, d.messages.map(toDiagnostic))
+    }
+
+  private def toDiagnostic(msg: semanticdb.Message): l.Diagnostic = {
+    l.Diagnostic(
+      range = msg.position.toRange,
+      severity = Some(toSeverity(msg.severity)),
+      code = None,
+      source = Some("scalac"),
+      message = msg.text
+    )
+  }
+
+  private def toSeverity(s: semanticdb.Severity): l.DiagnosticSeverity = s match {
+    case semanticdb.Severity.Error => l.DiagnosticSeverity.Error
+    case semanticdb.Severity.Warning => l.DiagnosticSeverity.Warning
+    case semanticdb.Severity.Info => l.DiagnosticSeverity.Information
+  }
+
+}

--- a/metaserver/src/main/scala/scala/meta/languageserver/ErrorReporter.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ErrorReporter.scala
@@ -40,10 +40,11 @@ class ScalacErrorReporter(
     )
   }
 
-  private def toSeverity(s: semanticdb.Severity): l.DiagnosticSeverity = s match {
-    case semanticdb.Severity.Error => l.DiagnosticSeverity.Error
-    case semanticdb.Severity.Warning => l.DiagnosticSeverity.Warning
-    case semanticdb.Severity.Info => l.DiagnosticSeverity.Information
-  }
+  private def toSeverity(s: semanticdb.Severity): l.DiagnosticSeverity =
+    s match {
+      case semanticdb.Severity.Error => l.DiagnosticSeverity.Error
+      case semanticdb.Severity.Warning => l.DiagnosticSeverity.Warning
+      case semanticdb.Severity.Info => l.DiagnosticSeverity.Information
+    }
 
 }

--- a/metaserver/src/main/scala/scala/meta/languageserver/Linter.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Linter.scala
@@ -71,15 +71,20 @@ class Linter(
       val configDecoder = ScalafixReflect.fromLazySemanticdbIndex(lazyIndex)
       val (rule, config) =
         ScalafixConfig.fromInput(configInput, lazyIndex)(configDecoder).get
-      val results: Seq[PublishDiagnostics] = index.database.documents.flatMap { d =>
-        Parser.parse(d).toOption.map { tree =>
-          val ctx = RuleCtx.applyInternal(tree, config)
-          val patches = rule.fixWithNameInternal(ctx)
-          val diagnostics =
-            Patch.lintMessagesInternal(patches, ctx).map(toDiagnostic)
-          val uri = d.input.syntax
-          PublishDiagnostics(uri, diagnostics)
-        }.toList
+      val results: Seq[PublishDiagnostics] = index.database.documents.flatMap {
+        d =>
+          Parser
+            .parse(d)
+            .toOption
+            .map { tree =>
+              val ctx = RuleCtx.applyInternal(tree, config)
+              val patches = rule.fixWithNameInternal(ctx)
+              val diagnostics =
+                Patch.lintMessagesInternal(patches, ctx).map(toDiagnostic)
+              val uri = d.input.syntax
+              PublishDiagnostics(uri, diagnostics)
+            }
+            .toList
       }
 
       // megaCache needs to die, if we forget this we will read stale

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
@@ -65,7 +65,9 @@ class ScalametaLanguageServer(
   val scalac: ScalacProvider = new ScalacProvider(config)
   val symbolIndex: SymbolIndex = SymbolIndex(cwd, connection, buffers, config)
   val scalafix: Linter = new Linter(cwd, stdout, connection)
-  val scalacErrorReporter: ScalacErrorReporter =  new ScalacErrorReporter(connection)
+  val scalacErrorReporter: ScalacErrorReporter = new ScalacErrorReporter(
+    connection
+  )
   val metaSemanticdbs: Observable[semanticdb.Database] =
     Observable.merge(
       fileSystemSemanticdbsPublisher.map(_.toDb(sourcepath = None)),
@@ -320,10 +322,15 @@ object ScalametaLanguageServer extends LazyLogging {
 
   def interactiveSemanticdbStream(cwd: AbsolutePath)(
       implicit scheduler: Scheduler
-  ): (Observer.Sync[(Global, VersionedTextDocumentIdentifier, String)], Observable[Database]) = {
-    val (subscriber, publisher) = multicast[(Global, VersionedTextDocumentIdentifier, String)]
-    val semanticdbPublisher = publisher.map { case (compiler, td, content) =>
-      Semanticdbs.loadFromTextDocument(compiler, td, content, cwd)
+  ): (
+      Observer.Sync[(Global, VersionedTextDocumentIdentifier, String)],
+      Observable[Database]
+  ) = {
+    val (subscriber, publisher) =
+      multicast[(Global, VersionedTextDocumentIdentifier, String)]
+    val semanticdbPublisher = publisher.map {
+      case (compiler, td, content) =>
+        Semanticdbs.loadFromTextDocument(compiler, td, content, cwd)
     }
     subscriber -> semanticdbPublisher
   }

--- a/metaserver/src/main/scala/scala/meta/languageserver/Semanticdbs.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Semanticdbs.scala
@@ -14,13 +14,20 @@ import ScalametaEnrichments._
 
 object Semanticdbs extends LazyLogging {
   def loadFromTextDocument(
-    compiler: Global,
-    td: VersionedTextDocumentIdentifier,
-    content: String,
-    cwd: AbsolutePath
+      compiler: Global,
+      td: VersionedTextDocumentIdentifier,
+      content: String,
+      cwd: AbsolutePath
   ): Database = {
     val documents = try {
-      List(InteractiveSemanticdb.toDocument(compiler, content, Uri.toPath(td.uri).get.toLanguageServerUri, 10000))
+      List(
+        InteractiveSemanticdb.toDocument(
+          compiler,
+          content,
+          Uri.toPath(td.uri).get.toLanguageServerUri,
+          10000
+        )
+      )
     } catch {
       case e: ParseException => Nil
     }

--- a/metaserver/src/main/scala/scala/meta/languageserver/Semanticdbs.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Semanticdbs.scala
@@ -4,8 +4,10 @@ import java.nio.file.Files
 import com.typesafe.scalalogging.LazyLogging
 import org.langmeta.internal.semanticdb.schema.Database
 import org.langmeta.io.AbsolutePath
+import org.langmeta.internal.semanticdb._
 import scala.meta.interactive.InteractiveSemanticdb
 import scala.meta.parsers.ParseException
+import scala.meta.semanticdb
 import scala.tools.nsc.interactive.Global
 import langserver.types.VersionedTextDocumentIdentifier
 import ScalametaEnrichments._
@@ -14,14 +16,15 @@ object Semanticdbs extends LazyLogging {
   def loadFromTextDocument(
     compiler: Global,
     td: VersionedTextDocumentIdentifier,
-    content: String
-  ): scala.meta.semanticdb.Database = {
+    content: String,
+    cwd: AbsolutePath
+  ): Database = {
     val documents = try {
       List(InteractiveSemanticdb.toDocument(compiler, content, Uri.toPath(td.uri).get.toLanguageServerUri, 10000))
     } catch {
       case e: ParseException => Nil
     }
-    scala.meta.semanticdb.Database(documents)
+    semanticdb.Database(documents).toSchema(cwd)
   }
   def loadFromFile(
       semanticdbPath: AbsolutePath,

--- a/metaserver/src/main/scala/scala/meta/languageserver/Semanticdbs.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Semanticdbs.scala
@@ -4,8 +4,25 @@ import java.nio.file.Files
 import com.typesafe.scalalogging.LazyLogging
 import org.langmeta.internal.semanticdb.schema.Database
 import org.langmeta.io.AbsolutePath
+import scala.meta.interactive.InteractiveSemanticdb
+import scala.meta.parsers.ParseException
+import scala.tools.nsc.interactive.Global
+import langserver.types.VersionedTextDocumentIdentifier
+import ScalametaEnrichments._
 
 object Semanticdbs extends LazyLogging {
+  def loadFromTextDocument(
+    compiler: Global,
+    td: VersionedTextDocumentIdentifier,
+    content: String
+  ): scala.meta.semanticdb.Database = {
+    val documents = try {
+      List(InteractiveSemanticdb.toDocument(compiler, content, Uri.toPath(td.uri).get.toLanguageServerUri, 10000))
+    } catch {
+      case e: ParseException => Nil
+    }
+    scala.meta.semanticdb.Database(documents)
+  }
   def loadFromFile(
       semanticdbPath: AbsolutePath,
       cwd: AbsolutePath

--- a/metaserver/src/main/scala/scala/meta/languageserver/compiler/ScalacProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/compiler/ScalacProvider.scala
@@ -11,6 +11,7 @@ import scala.tools.nsc.interactive.Response
 import scala.tools.nsc.reporters.StoreReporter
 import com.typesafe.scalalogging.LazyLogging
 import langserver.types.TextDocumentIdentifier
+import langserver.types.VersionedTextDocumentIdentifier
 import monix.execution.Scheduler
 import org.langmeta.io.AbsolutePath
 
@@ -23,6 +24,10 @@ class ScalacProvider(
 
   def getCompiler(td: TextDocumentIdentifier): Option[Global] =
     Uri.toPath(td.uri).flatMap(getCompiler)
+
+  def getCompiler(td: VersionedTextDocumentIdentifier): Option[Global] =
+    Uri.toPath(td.uri).flatMap(getCompiler)
+
   def getCompiler(path: AbsolutePath): Option[Global] = {
     compilerByPath.get(path).map { compiler =>
       compiler.reporter.reset()


### PR DESCRIPTION
This PR uses the new `InteractiveSemanticdb` facility (introduced by Scalameta 2.1.3) to produce an `Observable` of semantic dbs as you type.
This `Observable` is merged with the file system one (fed by semanticdb files written on disk by `semanticdb-scalac`).

The net result is that now Scalafix runs also as you type. Demo:

![](http://g.recordit.co/68Jn0fS6kQ.gif)

I think it still needs some polishing (sometimes the PC dies in an unexpected way, causing an exception to be thrown and the Observable to die) and ideally some tests.