### PR TITLE
Move all requests to Task[T]

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -82,6 +82,7 @@ lazy val languageserver = project
       "com.beachape" %% "enumeratum" % "1.5.12",
       "com.beachape" %% "enumeratum-play-json" % "1.5.12-2.6.0-M7",
       "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2",
+      "io.monix" %% "monix" % "2.3.0",
       "org.slf4j" % "slf4j-api" % "1.7.25",
       "ch.qos.logback" % "logback-classic" % "1.2.3",
       "org.codehaus.groovy" % "groovy" % "2.4.0",
@@ -107,7 +108,6 @@ lazy val metaserver = project
     libraryDependencies ++= List(
       "io.github.soc" % "directories" % "5",
       "org.fusesource.leveldbjni" % "leveldbjni-all" % "1.8",
-      "io.monix" %% "monix" % "2.3.0",
       "com.lihaoyi" %% "pprint" % "0.5.3",
       "com.thoughtworks.qdox" % "qdox" % "2.0-M7", // for java mtags
       "io.get-coursier" %% "coursier" % coursier.util.Properties.version,

--- a/languageserver/src/main/scala/langserver/core/Main.scala
+++ b/languageserver/src/main/scala/langserver/core/Main.scala
@@ -2,6 +2,7 @@ package langserver.core
 
 import com.typesafe.scalalogging.LazyLogging
 import scala.util.Try
+import monix.execution.Scheduler.Implicits.global
 
 object Main extends LazyLogging {
   def main(args: Array[String]): Unit = {

--- a/languageserver/src/main/scala/langserver/messages/Commands.scala
+++ b/languageserver/src/main/scala/langserver/messages/Commands.scala
@@ -288,6 +288,12 @@ case class DefinitionResult(params: Seq[Location]) extends ResultResponse
 case class ReferencesResult(params: Seq[Location]) extends ResultResponse
 case class DocumentHighlightResult(params: Seq[Location]) extends ResultResponse
 case class DocumentFormattingResult(params: Seq[TextEdit]) extends ResultResponse
+case class SignatureHelpResult(signatures: Seq[SignatureInformation],
+                               activeSignature: Option[Int],
+                               activeParameter: Option[Int]) extends ResultResponse
+object SignatureHelpResult {
+  implicit val format = Json.format[SignatureHelpResult]
+}
 
 object ResultResponse extends ResponseCompanion[Any] {
   import JsonRpcUtils._
@@ -295,7 +301,7 @@ object ResultResponse extends ResponseCompanion[Any] {
   override val ResponseFormats = Message.MessageFormats(
     "initialize" -> Json.format[InitializeResult],
     "textDocument/completion" -> Json.format[CompletionList],
-    "textDocument/signatureHelp" -> Json.format[SignatureHelp],
+    "textDocument/signatureHelp" -> Json.format[SignatureHelpResult],
     "textDocument/definition" -> valueFormat(DefinitionResult)(_.params),
     "textDocument/references" -> valueFormat(ReferencesResult)(_.params),
     "textDocument/documentHighlight" -> valueFormat(DocumentHighlightResult)(_.params),

--- a/languageserver/src/main/scala/langserver/types/types.scala
+++ b/languageserver/src/main/scala/langserver/types/types.scala
@@ -1,5 +1,6 @@
 package langserver.types
 
+import langserver.messages.ResultResponse
 import play.api.libs.json._
 
 /**
@@ -137,23 +138,6 @@ object SignatureInformation {
   implicit val format: OFormat[SignatureInformation] = Json.format[SignatureInformation]
 }
 
-/**
- * Signature help represents the signature of something
- * callable. There can be multiple signature but only one
- * active and only one active parameter.
- */
-case class SignatureHelp(
-  /** One or more signatures. */
-  signatures: Seq[SignatureInformation],
-
-  /** The active signature. */
-  activeSignature: Option[Int],
-
-  /** The active parameter of the active signature. */
-  activeParameter: Option[Int])
-object SignatureHelp {
-  implicit var format: OFormat[SignatureHelp] = Json.format[SignatureHelp]
-}
 
 /**
  * Value-object that contains additional information when

--- a/metaserver/src/main/scala/scala/meta/languageserver/Main.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Main.scala
@@ -2,10 +2,13 @@ package scala.meta.languageserver
 
 import java.io.FileOutputStream
 import java.io.PrintStream
+import java.util.concurrent.Executors
+import scala.concurrent.ExecutionContext
 import scala.util.Properties
 import com.typesafe.scalalogging.LazyLogging
+import monix.execution.Scheduler
+import monix.execution.schedulers.SchedulerService
 import org.langmeta.io.AbsolutePath
-import monix.execution.Scheduler.Implicits.global // TODO(olafur) may want to customize
 
 object Main extends LazyLogging {
   def main(args: Array[String]): Unit = {
@@ -19,6 +22,8 @@ object Main extends LazyLogging {
     val stdin = System.in
     val stdout = System.out
     val stderr = System.err
+    implicit val s: SchedulerService =
+      Scheduler(Executors.newFixedThreadPool(4))
     try {
       // route System.out somewhere else. Any output not from the server (e.g. logging)
       // messes up with the client, since stdout is used for the language server protocol

--- a/metaserver/src/main/scala/scala/meta/languageserver/providers/DocumentFormattingProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/providers/DocumentFormattingProvider.scala
@@ -1,0 +1,38 @@
+package scala.meta.languageserver.providers
+
+import java.nio.file.Files
+import scala.meta.languageserver.Buffers
+import scala.meta.languageserver.Formatter
+import scala.meta.languageserver.Uri
+import com.typesafe.scalalogging.LazyLogging
+import langserver.messages.DocumentFormattingResult
+import langserver.messages.TextDocumentFormattingRequest
+import langserver.types.Position
+import langserver.types.Range
+import langserver.types.TextEdit
+import org.langmeta.io.AbsolutePath
+
+object DocumentFormattingProvider extends LazyLogging {
+  def format(
+      request: TextDocumentFormattingRequest,
+      scalafmt: Formatter,
+      buffers: Buffers,
+      cwd: AbsolutePath
+  ): DocumentFormattingResult = {
+    val path = Uri.toPath(request.params.textDocument.uri).get
+    val contents = buffers.read(path)
+    val fullDocumentRange = Range(
+      start = Position(0, 0),
+      end = Position(Int.MaxValue, Int.MaxValue)
+    )
+    val config = cwd.resolve(".scalafmt.conf")
+    val edits = if (Files.isRegularFile(config.toNIO)) {
+      val formattedContent =
+        scalafmt.format(contents, path.toString(), config)
+      List(TextEdit(fullDocumentRange, formattedContent))
+    } else {
+      Nil
+    }
+    DocumentFormattingResult(edits)
+  }
+}

--- a/metaserver/src/main/scala/scala/meta/languageserver/providers/DocumentSymbolProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/providers/DocumentSymbolProvider.scala
@@ -1,12 +1,11 @@
 package scala.meta.languageserver.providers
 
-import scala.collection.mutable
-import com.typesafe.scalalogging.LazyLogging
-import org.langmeta.io.AbsolutePath
-import langserver.{types => l}
-import langserver.messages.DefinitionResult
-import scala.meta.languageserver.ScalametaEnrichments._
 import scala.meta._
+import scala.meta.languageserver.ScalametaEnrichments._
+import com.typesafe.scalalogging.LazyLogging
+import langserver.messages.DocumentSymbolResult
+import langserver.{types => l}
+import org.langmeta.io.AbsolutePath
 
 object DocumentSymbolProvider extends LazyLogging {
 
@@ -56,9 +55,10 @@ object DocumentSymbolProvider extends LazyLogging {
     }
   }
 
+  def empty = DocumentSymbolResult(Nil)
   def documentSymbols(
       path: AbsolutePath,
       source: Source
-  ): List[l.SymbolInformation] =
-    new SymbolTraverser(path).apply(source)
+  ): DocumentSymbolResult =
+    DocumentSymbolResult(new SymbolTraverser(path).apply(source))
 }

--- a/metaserver/src/main/scala/scala/meta/languageserver/providers/SignatureHelpProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/providers/SignatureHelpProvider.scala
@@ -7,13 +7,13 @@ import scala.meta.languageserver.compiler.CompilerUtils._
 import scala.reflect.internal.util.Position
 import scala.tools.nsc.interactive.Global
 import com.typesafe.scalalogging.LazyLogging
+import langserver.messages.SignatureHelpResult
 import langserver.types.ParameterInformation
-import langserver.types.SignatureHelp
 import langserver.types.SignatureInformation
 
 object SignatureHelpProvider extends LazyLogging {
-  def empty: SignatureHelp = SignatureHelp(Nil, None, None)
-  def signatureHelp(compiler: Global, cursor: Cursor): SignatureHelp = {
+  def empty: SignatureHelpResult = SignatureHelpResult(Nil, None, None)
+  def signatureHelp(compiler: Global, cursor: Cursor): SignatureHelpResult = {
     val unit = ScalacProvider.addCompilationUnit(
       global = compiler,
       code = cursor.contents,
@@ -82,7 +82,7 @@ object SignatureHelpProvider extends LazyLogging {
       val activeArgument: Int =
         if (isVararg) signatureInformations.map(_.parameters.length - 1).max
         else callSite.activeArgument
-      SignatureHelp(
+      SignatureHelpResult(
         signatures = signatureInformations,
         // TODO(olafur) populate activeSignature and activeParameter fields, see
         // https://github.com/scalameta/language-server/issues/52

--- a/metaserver/src/test/scala/tests/compiler/SignatureHelpTest.scala
+++ b/metaserver/src/test/scala/tests/compiler/SignatureHelpTest.scala
@@ -2,7 +2,7 @@ package tests.compiler
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.meta.languageserver.providers.SignatureHelpProvider
-import langserver.types.SignatureHelp
+import langserver.messages.SignatureHelpResult
 import play.api.libs.json.Json
 
 object SignatureHelpTest extends CompilerSuite {
@@ -10,7 +10,7 @@ object SignatureHelpTest extends CompilerSuite {
   def check(
       filename: String,
       code: String,
-      fn: SignatureHelp => Unit
+      fn: SignatureHelpResult => Unit
   ): Unit = {
     targeted(
       filename,


### PR DESCRIPTION
Previously, all messages were handled synchronously.  This made it
tricky to implement desirable features like request cancellation and
restarting crashing presentation compiler. This commit is the first
step towards making it easier to fix these problems by porting to
monix Task[T]. The main motivation to use monix task instead of stdlib
Future is cancellation and overflow strategies (drop old messages with
configurable buffer size) are provided out of the box. Monix
TestScheduler makes it also easy to test the server synchronously.
Task[T].runAsync returns a stdlib future which makes it fit perfectly
into the existing code with language-server, we never need to block.