### PR TITLE
ScalaMtags computes a wrong symbol for members in package objects

### DIFF
--- a/metaserver/src/main/scala/scala/meta/languageserver/mtags/ScalaMtags.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/mtags/ScalaMtags.scala
@@ -23,7 +23,10 @@ object ScalaMtags {
           case t: Source => continue()
           case t: Template => continue()
           case t: Pkg => pkg(t.ref); continue()
-          case t: Pkg.Object => term(t.name, PACKAGEOBJECT); continue()
+          case t: Pkg.Object =>
+            term(t.name, PACKAGEOBJECT);
+            term("package", t.name.pos, OBJECT);
+            continue()
           case t: Defn.Class => tpe(t.name, CLASS); continue()
           case t: Defn.Trait => tpe(t.name, TRAIT); continue()
           case t: Defn.Object => term(t.name, OBJECT); continue()

--- a/metaserver/src/test/scala/tests/mtags/ScalaMtagsTest.scala
+++ b/metaserver/src/test/scala/tests/mtags/ScalaMtagsTest.scala
@@ -17,9 +17,6 @@ object ScalaMtagsTest extends BaseMtagsTest {
       |   }
       |   object J { def k = 2 }
       |}
-      |package object K {
-      |  def l = 2
-      |}
       """.stripMargin,
     """
       |Language:
@@ -38,8 +35,6 @@ object ScalaMtagsTest extends BaseMtagsTest {
       |[159..160): z <= _root_.a.b.c.D.I#z.
       |[181..182): J <= _root_.a.b.c.D.J.
       |[189..190): k <= _root_.a.b.c.D.J.k.
-      |[214..215): K <= _root_.a.b.c.K.
-      |[224..225): l <= _root_.a.b.c.K.package.l.
       |
       |Symbols:
       |_root_.a.b.c.D. => object D
@@ -54,9 +49,30 @@ object ScalaMtagsTest extends BaseMtagsTest {
       |_root_.a.b.c.D.e. => def e
       |_root_.a.b.c.D.f. => val f
       |_root_.a.b.c.D.g. => var g
-      |_root_.a.b.c.K. => packageobject K
-      |_root_.a.b.c.K.l. => def l
       """.stripMargin
+  )
+
+  check(
+    "pkgobject.scala",
+    """
+      |package object K {
+      |  def l = 2
+      |}
+    """.stripMargin,
+    """
+      |Language:
+      |Scala212
+      |
+      |Names:
+      |[16..17): K <= _root_.K.
+      |[16..17): K <= _root_.K.package.
+      |[26..27): l <= _root_.K.package.l.
+      |
+      |Symbols:
+      |_root_.K. => packageobject K
+      |_root_.K.package. => object package
+      |_root_.K.package.l. => def l
+    """.stripMargin
   )
 
   check(

--- a/metaserver/src/test/scala/tests/mtags/ScalaMtagsTest.scala
+++ b/metaserver/src/test/scala/tests/mtags/ScalaMtagsTest.scala
@@ -39,7 +39,7 @@ object ScalaMtagsTest extends BaseMtagsTest {
       |[181..182): J <= _root_.a.b.c.D.J.
       |[189..190): k <= _root_.a.b.c.D.J.k.
       |[214..215): K <= _root_.a.b.c.K.
-      |[224..225): l <= _root_.a.b.c.K.l.
+      |[224..225): l <= _root_.a.b.c.K.package.l.
       |
       |Symbols:
       |_root_.a.b.c.D. => object D

--- a/metaserver/src/test/scala/tests/search/SymbolIndexTest.scala
+++ b/metaserver/src/test/scala/tests/search/SymbolIndexTest.scala
@@ -177,6 +177,8 @@ object SymbolIndexTest extends MegaSuite {
         assertSymbolFound(5, 5)("_root_.scala.collection.immutable.List.")
       "<<CharRef>>.create(...)" - // JavaMtags
         assertSymbolFound(8, 19)("_root_.scala.runtime.CharRef.")
+      "<<Either>>[...]" -
+        assertSymbolFound(10, 15)("_root_.scala.util.Either#")
     }
 
     "references" - {

--- a/metaserver/src/test/scala/tests/search/SymbolIndexTest.scala
+++ b/metaserver/src/test/scala/tests/search/SymbolIndexTest.scala
@@ -177,8 +177,6 @@ object SymbolIndexTest extends MegaSuite {
         assertSymbolFound(5, 5)("_root_.scala.collection.immutable.List.")
       "<<CharRef>>.create(...)" - // JavaMtags
         assertSymbolFound(8, 19)("_root_.scala.runtime.CharRef.")
-      "<<Either>>[...]" -
-        assertSymbolFound(10, 15)("_root_.scala.util.Either#")
     }
 
     "references" - {

--- a/test-workspace/src/test/scala/example/UserTest.scala
+++ b/test-workspace/src/test/scala/example/UserTest.scala
@@ -8,4 +8,5 @@ class UserTest {
     .map(x => x.+(user.age))
   scala.runtime.CharRef.create('a')
   val str = user.name + a.a.x
+  val left: Either[String, Int] = Left("")
 }


### PR DESCRIPTION
Given 

```scala
package object K {
  val x = 42
}
```

the symbol for `x` should be `_root.K.`package`.x`. Right now it's `_root_.K.x`