### PR TITLE
Get server back into working state

### DIFF
--- a/languageserver/src/main/scala/langserver/core/Connection.scala
+++ b/languageserver/src/main/scala/langserver/core/Connection.scala
@@ -55,10 +55,6 @@ abstract class Connection(inStream: InputStream, outStream: OutputStream)(implic
     sendNotification(ShowMessageParams(tpe, message))
   }
 
-  def showMessage(tpe: MessageType, message: String, actions: String*): Unit = {
-    ???
-  }
-
   /**
    * The log message notification is sent from the server to the client to ask
    * the client to log a particular message.

--- a/languageserver/src/main/scala/langserver/core/LanguageServer.scala
+++ b/languageserver/src/main/scala/langserver/core/LanguageServer.scala
@@ -23,7 +23,7 @@ class LanguageServer(inStream: InputStream, outStream: OutputStream)(implicit s:
       case ("textDocument/hover", request: TextDocumentHoverRequest) => hover(request)
       case ("textDocument/references", request: TextDocumentReferencesRequest) => references(request)
       case ("textDocument/signatureHelp", request: TextDocumentSignatureHelpRequest) => signatureHelp(request)
-      case ("shutdown", request: Shutdown) => shutdown(request)
+      case ("shutdown", _: Shutdown) => shutdown()
       case c => Task.raiseError(new IllegalArgumentException(s"Unknown command $c"))
     }
   }
@@ -55,7 +55,7 @@ class LanguageServer(inStream: InputStream, outStream: OutputStream)(implicit s:
     logger.debug(s"initialize with $request")
     InitializeResult(ServerCapabilities())
   }
-  def shutdown(request: Shutdown): Task[ShutdownResult] =
+  def shutdown(): Task[ShutdownResult] =
     Task.now(ShutdownResult())
 
   // textDocument

--- a/languageserver/src/main/scala/langserver/core/LanguageServer.scala
+++ b/languageserver/src/main/scala/langserver/core/LanguageServer.scala
@@ -28,9 +28,8 @@ class LanguageServer(inStream: InputStream, outStream: OutputStream)(implicit s:
     }
   }
 
-  protected val documentManager = new TextDocumentManager(connection)
-
   connection.notificationHandlers += {
+    case Initialized() => logger.info("Client has initialized")
     case Exit() => onExit()
     case DidOpenTextDocumentParams(td) => onOpenTextDocument(td)
     case DidChangeTextDocumentParams(td, changes) => onChangeTextDocument(td, changes)

--- a/metaserver/src/main/resources/logback.groovy
+++ b/metaserver/src/main/resources/logback.groovy
@@ -13,3 +13,5 @@ appender("LSP", scala.meta.languageserver.LSPLogger) {
 }
 
 root(DEBUG, ["LSP", "STDOUT"])
+logger("langserver.core.MessageWriter", INFO, ["LSP", "STDOUT"])
+logger("langserver.core.MessageReader", INFO, ["LSP", "STDOUT"])

--- a/metaserver/src/main/scala/scala/meta/languageserver/LSPLogger.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/LSPLogger.scala
@@ -14,13 +14,10 @@ class LSPLogger(@BeanProperty var encoder: PatternLayoutEncoder)
   import LSPLogger._
 
   override def append(event: ILoggingEvent): Unit = {
-    // Skip rpc message noise.
-    if (!event.getLoggerName.startsWith("langserver.core.Message")) {
-      val message =
-        if (encoder != null) new String(encoder.encode(event), UTF_8)
-        else event.getFormattedMessage
-      connection.foreach(_.logMessage(MessageType.Log, message))
-    }
+    val message =
+      if (encoder != null) new String(encoder.encode(event), UTF_8)
+      else event.getFormattedMessage
+    connection.foreach(_.logMessage(MessageType.Log, message))
   }
 }
 

--- a/metaserver/src/main/scala/scala/meta/languageserver/LSPLogger.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/LSPLogger.scala
@@ -14,10 +14,13 @@ class LSPLogger(@BeanProperty var encoder: PatternLayoutEncoder)
   import LSPLogger._
 
   override def append(event: ILoggingEvent): Unit = {
-    val message =
-      if (encoder != null) new String(encoder.encode(event), UTF_8)
-      else event.getFormattedMessage
-    connection.foreach(_.logMessage(MessageType.Log, message))
+    // Skip rpc message noise.
+    if (!event.getLoggerName.startsWith("langserver.core.Message")) {
+      val message =
+        if (encoder != null) new String(encoder.encode(event), UTF_8)
+        else event.getFormattedMessage
+      connection.foreach(_.logMessage(MessageType.Log, message))
+    }
   }
 }
 

--- a/metaserver/src/test/scala/tests/search/SymbolIndexTest.scala
+++ b/metaserver/src/test/scala/tests/search/SymbolIndexTest.scala
@@ -61,7 +61,7 @@ object SymbolIndexTest extends MegaSuite {
   // TODO(olafur) run this as part of utest.runner.Framework.setup()
   val server =
     new ScalametaLanguageServer(config, stdin, stdout, System.out)(s)
-  server.initialize(0L, cwd.toString(), ClientCapabilities())
+  server.initialize(0L, cwd.toString(), ClientCapabilities()).runAsync(s)
   while (s.tickOne()) () // Trigger indexing
   val index: SymbolIndex = server.symbolIndex
   val reminderMsg = "Did you run scalametaEnableCompletions from sbt?"


### PR DESCRIPTION
The combination of #104 #103 and #100 made the server almost unusable. This PR tries to repair a bit of the damage by

- pushing notifications and commands onto the `Scheduler` instead of main thread. Commands were accidentally running on the main thread because I used `Task.now` 😅 . Notifications were also blocking the main thread because we compile on every change after #100.
- disable interactive semanticdb #100, scalac and scalafix were racing to publish diagnostics making red squigglies jitter in the editor. I propose we dedicate a PR to fix that issue, this PR is only about returning the server to a functioning state for people who checkout master.
- reduce the logging noise to the clients from #103 by skipping Message{Reader/Writer} entries. Maybe there's a better way to implement that filter in logback.groovy, but my logback/groovy foo is not great