### PR TITLE
Add command in VSCode extension to restart the server

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -13,6 +13,13 @@
     "activationEvents": [
         "onLanguage:scala"
     ],
+    "contributes": {
+        "commands": [{
+            "command": "scalameta.restartServer",
+            "category": "Scalameta Language Server",
+            "title": "Restart server"
+        }]
+    },
     "main": "./out/extension",
     "scripts": {
         "vscode:prepublish": "npm run download-coursier && npm run compile",

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -78,7 +78,8 @@ export async function activate(context: ExtensionContext) {
   );
 
   const restartServerCommand = commands.registerCommand("scalameta.restartServer", async () => {
-    await exec("jps | grep coursier | awk '{ print $1 }' | xargs kill");
+    const serverPid = client['_serverProcess'].pid;
+    await exec(`kill ${serverPid}`);
     const showLogsAction = "Show server logs";
     const selectedAction = await window.showInformationMessage(
       "Scalameta Language Server killed, it should restart in a few seconds",

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -85,7 +85,6 @@ export async function activate(context: ExtensionContext) {
       "Scalameta Language Server killed, it should restart in a few seconds",
       showLogsAction
     );
-    const myOutputChannel = window.createOutputChannel('Scalameta');
 
     if (selectedAction === showLogsAction) {
       client.outputChannel.show(true);


### PR DESCRIPTION
This is a client-specific command to help with debugging, especially while we're dealing with PC issues that may stall the server.

Example:

![](http://g.recordit.co/PgatEzOlRy.gif)