### PR TITLE
Avoid ever returning `<notype>` to the client

### DIFF
--- a/metaserver/src/main/scala/scala/meta/languageserver/providers/HoverProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/providers/HoverProvider.scala
@@ -44,7 +44,8 @@ object HoverProvider {
     stringOrTree match {
       case Right(string) => Some(string)
       case Left(null) => None
-      case Left(tree) => Some(tree.tpe.widen.toString)
+      case Left(tree) if tree.tpe ne NoType => Some(tree.tpe.widen.toString)
+      case _ => None
     }
 
   }

--- a/metaserver/src/test/scala/tests/hover/HoverTest.scala
+++ b/metaserver/src/test/scala/tests/hover/HoverTest.scala
@@ -27,6 +27,24 @@ object HoverTest extends CompilerSuite {
     )
   }
 
+  def checkMissing(
+      filename: String,
+      code: String
+  ): Unit = {
+    targeted(
+      filename,
+      code, { point =>
+        val result = HoverProvider.hover(compiler, point)
+        val obtained = Json.prettyPrint(Json.toJson(result))
+        val expected =
+          s"""{
+             |  "contents" : [ ]
+             |}""".stripMargin
+        assertNoDiff(obtained, expected)
+      }
+    )
+  }
+
   check(
     "val assignment",
     """
@@ -128,6 +146,21 @@ object HoverTest extends CompilerSuite {
       |}
     """.stripMargin,
     "(x: String, y: List[Int])Int"
+  )
+
+  checkMissing(
+    "keywords",
+    """
+      |cl<<a>>ss A(x: Int, y: String)
+    """.stripMargin
+  )
+
+  // FIXME(gabro): this should return "A"
+  checkMissing(
+    "class",
+    """
+      |class <<A>>(x: Int, y: String)
+    """.stripMargin
   )
 
 }

--- a/metaserver/src/test/scala/tests/hover/HoverTest.scala
+++ b/metaserver/src/test/scala/tests/hover/HoverTest.scala
@@ -35,12 +35,7 @@ object HoverTest extends CompilerSuite {
       filename,
       code, { point =>
         val result = HoverProvider.hover(compiler, point)
-        val obtained = Json.prettyPrint(Json.toJson(result))
-        val expected =
-          s"""{
-             |  "contents" : [ ]
-             |}""".stripMargin
-        assertNoDiff(obtained, expected)
+        assert(result.contents.isEmpty)
       }
     )
   }


### PR DESCRIPTION
This partially addresses #125. We are still missing hovers in some obvious spots, but at least we're not returning `<notype>` to the client.