### PR TITLE
Implement $/cancelRequest, fixes #118.

### DIFF
--- a/languageserver/src/main/scala/langserver/core/LanguageServer.scala
+++ b/languageserver/src/main/scala/langserver/core/LanguageServer.scala
@@ -40,6 +40,7 @@ class LanguageServer(inStream: InputStream, outStream: OutputStream)(implicit s:
     case e => logger.error(s"Unknown notification $e")
   }
 
+
   // lifecycle
   def start(): Unit = {
     connection.start()

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
@@ -182,6 +182,7 @@ class ScalametaLanguageServer(
   override def shutdown(): Task[ShutdownResult] = Task {
     logger.info("Shutting down...")
     cancelEffects.foreach(_.cancel())
+    connection.cancelAllActiveRequests()
     ShutdownResult()
   }
 


### PR DESCRIPTION
This PR implements the CancelRequest(id) message. It doesn't seem
like this has any immediate effect on the server since our Task[T] are
quite shallow. When we do `.cancel()`, monix will not interrupt an
ongoing step, it will only stop executing a Task between map/flatMap/...
Good motivation for us to write more inside Task.

Only relevant commit is d61f1ef