### PR TITLE
Remove unnecessary -Dvscode.workspace argument.

### DIFF
--- a/metaserver/src/main/scala/scala/meta/languageserver/Main.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Main.scala
@@ -2,23 +2,22 @@ package scala.meta.languageserver
 
 import java.io.FileOutputStream
 import java.io.PrintStream
+import java.nio.file.Files
 import java.util.concurrent.Executors
 import scala.concurrent.ExecutionContext
 import scala.util.Properties
 import com.typesafe.scalalogging.LazyLogging
 import monix.execution.Scheduler
 import monix.execution.schedulers.SchedulerService
-import org.langmeta.io.AbsolutePath
+import org.langmeta.internal.io.PathIO
 
 object Main extends LazyLogging {
   def main(args: Array[String]): Unit = {
-    // FIXME(gabro): this is vscode specific (at least the name)
-    val workspace = System.getProperty("vscode.workspace")
-    val logPath = s"$workspace/target/metaserver.log"
-    val out = new PrintStream(new FileOutputStream(logPath))
-    val err = new PrintStream(new FileOutputStream(logPath))
-    val cwd = AbsolutePath(workspace)
+    val cwd = PathIO.workingDirectory
     val config = ServerConfig(cwd)
+    Files.createDirectories(config.configDir.toNIO)
+    val out = new PrintStream(new FileOutputStream(config.logFile))
+    val err = new PrintStream(new FileOutputStream(config.logFile))
     val stdin = System.in
     val stdout = System.out
     val stderr = System.err
@@ -29,7 +28,7 @@ object Main extends LazyLogging {
       // messes up with the client, since stdout is used for the language server protocol
       System.setOut(out)
       System.setErr(err)
-      logger.info(s"Starting server in $workspace")
+      logger.info(s"Starting server in $cwd")
       logger.info(s"Classpath: ${Properties.javaClassPath}")
       val server = new ScalametaLanguageServer(config, stdin, stdout, out)
       LSPLogger.connection = Some(server.connection)

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
@@ -1,5 +1,6 @@
 package scala.meta.languageserver
 
+import java.io.File
 import java.io.InputStream
 import java.io.OutputStream
 import java.io.PrintStream
@@ -57,7 +58,10 @@ case class ServerConfig(
     // TODO(olafur): re-enable indexJDK after https://github.com/scalameta/language-server/issues/43 is fixed
     indexJDK: Boolean = false,
     indexClasspath: Boolean = true
-)
+) {
+  lazy val configDir: AbsolutePath = cwd.resolve(".metaserver")
+  lazy val logFile: File = configDir.resolve("metaserver.log").toFile
+}
 
 class ScalametaLanguageServer(
     config: ServerConfig,

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -26,10 +26,6 @@ export async function activate(context: ExtensionContext) {
     '-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8000,quiet=y'
   ];
 
-  // TODO(gabro): get this from th configuration
-  // const logLevel = workspace.getConfiguration().get('scalaLanguageServer.logLevel')
-  const logLevel = 'DEBUG';
-
   const coursierPath = path.join(context.extensionPath, './coursier');
 
   const coursierArgs = [
@@ -46,8 +42,6 @@ export async function activate(context: ExtensionContext) {
   ];
 
   const javaArgs = [
-    `-Dvscode.workspace=${workspace.rootPath}`,
-    `-Dvscode.logLevel=${logLevel}`,
     `-XX:+UseG1GC`,
     `-XX:+UseStringDeduplication`,
     '-jar',


### PR DESCRIPTION
The logs are emitted in `<working directory>/.metaserver/metaserver.log`
I didn't use the `directories` project to get the path because it
assumes you want a different location for config/cache and there is no
log-specific option. I personally want all metaserver files to be
bundled in the same directory so I can `rm -rf .metaserver`.

Fixes #112 

I'm itching to start using the plugin for my development but I found this issue made it awkward to start the server from neovim.