### PR TITLE
Enable scalafix and -Xlint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ project/plugins/project/
 # ENSIME specific
 .ensime_cache/
 .ensime
+
+.metaserver

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,3 +1,11 @@
 rules = [
-  NoInfer
+  Disable
+  RemoveUnusedImports
+  ExplicitResultTypes
+]
+
+ExplicitResultTypes.unsafeShortenNames = true
+
+Disable.symbols = [
+  "scala.Predef.any2stringadd"
 ]

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,9 @@ jobs:
     # default stage is test
     - env: TEST="scalafmt"
       script: ./bin/scalafmt --test
-    - env: TEST="scalafix"
-      script: sbt scalafixTest
     - env: TEST="sbt test"
-      script: sbt *:scalametaEnableCompletions test
+      script:
+        - sbt *:scalametaEnableCompletions test scalafixTest
     # release only on merge commits or tags
     - stage: release
       script: if [[ "$(git rev-list --merges HEAD^..HEAD)" || "$TRAVIS_TAG" ]]; then sbt releaseEarly; else echo "skipping release"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ jobs:
     # default stage is test
     - env: TEST="scalafmt"
       script: ./bin/scalafmt --test
+    - env: TEST="scalafix"
+      script: sbt scalafixTest
     - env: TEST="sbt test"
       script: sbt *:scalametaEnableCompletions test
     # release only on merge commits or tags

--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,11 @@ inThisBuild(
         else "0.1-SNAPSHOT" // to avoid manually updating extension.js
       },
       scalaVersion := V.scala212,
+      scalacOptions ++= List(
+        "-deprecation",
+        "-Xlint"
+      ),
+      scalafixEnabled := false,
       organization := "org.scalameta",
       licenses := Seq(
         "Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")
@@ -135,5 +140,7 @@ lazy val testWorkspace = project
     scalacOptions += {
       // Need to fix source root so it matches the workspace folder.
       s"-P:semanticdb:sourceroot:${baseDirectory.value}"
-    }
+    },
+    scalacOptions -= "-Xlint"
   )
+  .disablePlugins(ScalafixPlugin)

--- a/languageserver/src/main/scala/langserver/core/MessageReader.scala
+++ b/languageserver/src/main/scala/langserver/core/MessageReader.scala
@@ -3,7 +3,6 @@ package langserver.core
 import java.io.InputStream
 import java.nio.charset.Charset
 
-import scala.annotation.tailrec
 import scala.collection.mutable.ArrayBuffer
 import com.typesafe.scalalogging.LazyLogging
 
@@ -96,7 +95,7 @@ class MessageReader(in: InputStream) extends LazyLogging {
 
       // if there was a malformed header we keep trying to re-sync and read again
       if (pairs.exists(_ == EmptyPair)) {
-        logger.error("There was an empty pair in $pairs, trying to read another header.")
+        logger.error(s"There was an empty pair in $pairs, trying to read another header.")
         getHeaders
       } else pairs.toMap
     } else if (streamClosed) {

--- a/languageserver/src/main/scala/langserver/core/MessageWriter.scala
+++ b/languageserver/src/main/scala/langserver/core/MessageWriter.scala
@@ -2,7 +2,6 @@ package langserver.core
 
 import java.io.OutputStream
 import play.api.libs.json._
-import java.nio.charset.Charset
 import com.typesafe.scalalogging.LazyLogging
 
 /**

--- a/languageserver/src/main/scala/langserver/core/TextDocument.scala
+++ b/languageserver/src/main/scala/langserver/core/TextDocument.scala
@@ -1,6 +1,5 @@
 package langserver.core
 
-import langserver.types.TextDocumentIdentifier
 import langserver.types.TextDocumentContentChangeEvent
 import langserver.types.Position
 import java.io.File
@@ -58,7 +57,7 @@ case class TextDocument(uri: String, contents: Array[Char]) {
   def positionToOffset(pos: Position): Int = {
     val Position(line, col) = pos
 
-    var i, l, c = 0
+    var i, l = 0
     while (i < contents.size && l < line) {
       contents(i) match {
         case '\r' =>

--- a/languageserver/src/main/scala/langserver/messages/Commands.scala
+++ b/languageserver/src/main/scala/langserver/messages/Commands.scala
@@ -1,10 +1,10 @@
 package langserver.messages
 
-import play.api.libs.json.JsObject
 import com.dhpcs.jsonrpc._
 import play.api.libs.json._
 import langserver.types._
 import langserver.utils.JsonRpcUtils
+import play.api.libs.json.OFormat
 
 sealed trait Message
 sealed trait ServerCommand extends Message
@@ -114,7 +114,7 @@ case class ServerCapabilities(
 )
 
 object ServerCapabilities {
-  implicit val format = Json.format[ServerCapabilities]
+  implicit val format: OFormat[ServerCapabilities] = Json.format[ServerCapabilities]
 }
 
 case class CompletionOptions(resolveProvider: Boolean, triggerCharacters: Seq[String])
@@ -144,7 +144,7 @@ object ExecuteCommandOptions {
 
 case class CompletionList(isIncomplete: Boolean, items: Seq[CompletionItem]) extends ResultResponse
 object CompletionList {
-  implicit val format = Json.format[CompletionList]
+  implicit val format: OFormat[CompletionList] = Json.format[CompletionList]
 }
 
 case class InitializeResult(capabilities: ServerCapabilities) extends ResultResponse
@@ -178,7 +178,7 @@ case class ShowMessageRequestParams(
  */
 case class MessageActionItem(title: String)
 object MessageActionItem {
-  implicit val format = Json.format[MessageActionItem]
+  implicit val format: OFormat[MessageActionItem] = Json.format[MessageActionItem]
 }
 
 case class TextDocumentPositionParams(
@@ -203,14 +203,14 @@ case class WorkspaceExecuteCommandRequest(params: WorkspaceExecuteCommandParams)
 
 case class Hover(contents: Seq[MarkedString], range: Option[Range]) extends ResultResponse
 object Hover {
-  implicit val format = Json.format[Hover]
+  implicit val format: OFormat[Hover] = Json.format[Hover]
 }
 
 object ServerCommand extends CommandCompanion[ServerCommand] {
   import JsonRpcUtils._
 
-  implicit val positionParamsFormat = Json.format[TextDocumentPositionParams]
-  implicit val referenceParamsFormat = Json.format[ReferenceParams]
+  implicit val positionParamsFormat: OFormat[TextDocumentPositionParams] = Json.format[TextDocumentPositionParams]
+  implicit val referenceParamsFormat: OFormat[ReferenceParams] = Json.format[ReferenceParams]
 
   override val CommandFormats = Message.MessageFormats(
     "initialize" -> Json.format[InitializeParams],
@@ -306,7 +306,7 @@ case class SignatureHelpResult(signatures: Seq[SignatureInformation],
                                activeParameter: Option[Int]) extends ResultResponse
 case object ExecuteCommandResult extends ResultResponse
 object SignatureHelpResult {
-  implicit val format = Json.format[SignatureHelpResult]
+  implicit val format: OFormat[SignatureHelpResult] = Json.format[SignatureHelpResult]
 }
 
 object ResultResponse extends ResponseCompanion[Any] {

--- a/languageserver/src/main/scala/langserver/types/enums.scala
+++ b/languageserver/src/main/scala/langserver/types/enums.scala
@@ -1,7 +1,5 @@
 package langserver.types
 
-import play.api.libs.json._
-import enumeratum._
 import enumeratum.values._
 
 sealed abstract class DiagnosticSeverity(val value: Int) extends IntEnumEntry

--- a/languageserver/src/main/scala/langserver/types/types.scala
+++ b/languageserver/src/main/scala/langserver/types/types.scala
@@ -1,26 +1,26 @@
 package langserver.types
 
-import langserver.messages.ResultResponse
 import play.api.libs.json._
+import play.api.libs.json.OFormat
 
 /**
  * Position in a text document expressed as zero-based line and character offset.
  */
 case class Position(line: Int, character: Int)
-object Position { implicit val format = Json.format[Position] }
+object Position { implicit val format: OFormat[Position] = Json.format[Position] }
 
 /**
  * A range in a text document.
  */
 case class Range(start: Position, end: Position)
-object Range { implicit val format = Json.format[Range] }
+object Range { implicit val format: OFormat[Range] = Json.format[Range] }
 
 /**
  * Represents a location inside a resource, such as a line
  * inside a text file.
  */
 case class Location(uri: String, range: Range)
-object Location { implicit val format = Json.format[Location] }
+object Location { implicit val format: OFormat[Location] = Json.format[Location] }
 
 /**
   * Represents a diagnostic, such as a compiler error or warning. Diagnostic objects are only valid
@@ -40,7 +40,7 @@ case class Diagnostic(
   message: String
 )
 object Diagnostic {
-  implicit val format = Json.format[Diagnostic]
+  implicit val format: OFormat[Diagnostic] = Json.format[Diagnostic]
 }
 
 /**
@@ -55,7 +55,7 @@ case class Command(title: String, command: String, arguments: Seq[Any])
 case class TextEdit(range: Range, newText: String)
 
 object TextEdit {
-  implicit val formatter = Json.format[TextEdit]
+  implicit val formatter: OFormat[TextEdit] = Json.format[TextEdit]
 }
 
 /**
@@ -67,10 +67,10 @@ case class WorkspaceEdit(
   )
 
 case class TextDocumentIdentifier(uri: String)
-object TextDocumentIdentifier { implicit val format = Json.format[TextDocumentIdentifier] }
+object TextDocumentIdentifier { implicit val format: OFormat[TextDocumentIdentifier] = Json.format[TextDocumentIdentifier] }
 
 case class VersionedTextDocumentIdentifier(uri: String, version: Long)
-object VersionedTextDocumentIdentifier { implicit val format = Json.format[VersionedTextDocumentIdentifier] }
+object VersionedTextDocumentIdentifier { implicit val format: OFormat[VersionedTextDocumentIdentifier] = Json.format[VersionedTextDocumentIdentifier] }
 
 /**
  * An item to transfer a text document from the client to the
@@ -87,7 +87,7 @@ case class TextDocumentItem(
   text: String)
 
 object TextDocumentItem {
-  implicit val format = Json.format[TextDocumentItem]
+  implicit val format: OFormat[TextDocumentItem] = Json.format[TextDocumentItem]
 }
 
 case class CompletionItem(
@@ -104,7 +104,7 @@ case class CompletionItem(
 //   (#CompletionResolveRequest)
 
 object CompletionItem {
-  implicit def format = Json.format[CompletionItem]
+  implicit def format: OFormat[CompletionItem] = Json.format[CompletionItem]
 }
 
 trait MarkedString
@@ -169,7 +169,7 @@ case class SymbolInformation(
   location: Location,
   containerName: Option[String])
 object SymbolInformation {
-  implicit val format = Json.format[SymbolInformation]
+  implicit val format: OFormat[SymbolInformation] = Json.format[SymbolInformation]
 }
 
 /**
@@ -225,7 +225,7 @@ case class FormattingOptions(
 )
 
 object FormattingOptions {
-  implicit val formatter = Json.format[FormattingOptions]
+  implicit val formatter: OFormat[FormattingOptions] = Json.format[FormattingOptions]
 }
 
 trait TextDocument {
@@ -298,7 +298,7 @@ case class TextDocumentContentChangeEvent(
 )
 
 object TextDocumentContentChangeEvent {
-  implicit val format = Json.format[TextDocumentContentChangeEvent]
+  implicit val format: OFormat[TextDocumentContentChangeEvent] = Json.format[TextDocumentContentChangeEvent]
 }
 
 case class DocumentFormattingParams(
@@ -314,12 +314,12 @@ case class DocumentFormattingParams(
 )
 
 object DocumentFormattingParams {
-  implicit val format = Json.format[DocumentFormattingParams]
+  implicit val format: OFormat[DocumentFormattingParams] = Json.format[DocumentFormattingParams]
 }
 
 case class WorkspaceExecuteCommandParams(command: String, arguments: Option[Seq[JsValue]])
 object WorkspaceExecuteCommandParams {
-  implicit val format = Json.format[WorkspaceExecuteCommandParams]
+  implicit val format: OFormat[WorkspaceExecuteCommandParams] = Json.format[WorkspaceExecuteCommandParams]
 }
 
 
@@ -334,5 +334,5 @@ case class FileEvent(
   `type`: FileChangeType
 )
 object FileEvent {
-  implicit val format = Json.format[FileEvent]
+  implicit val format: OFormat[FileEvent] = Json.format[FileEvent]
 }

--- a/languageserver/src/test/scala/langserver/core/MessageWriterSuite.scala
+++ b/languageserver/src/test/scala/langserver/core/MessageWriterSuite.scala
@@ -4,7 +4,6 @@ import java.io.PipedInputStream
 import java.io.PipedOutputStream
 
 import org.scalatest.BeforeAndAfter
-import org.scalatest.Finders
 import org.scalatest.FunSuite
 import org.scalatest.OptionValues
 

--- a/languageserver/src/test/scala/langserver/messages/CommandProtocolTest.scala
+++ b/languageserver/src/test/scala/langserver/messages/CommandProtocolTest.scala
@@ -3,7 +3,6 @@ package langserver.messages
 
 
 import org.scalatest.FunSuite
-import langserver.types.Position
 
 class CommandProtocolSuite extends FunSuite {
   test("ServerCommand instantiastes") {

--- a/metaserver/src/main/scala/scala/meta/languageserver/Buffers.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Buffers.scala
@@ -1,16 +1,13 @@
 package scala.meta.languageserver
 
-import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
-import java.nio.file.Paths
 import java.util.concurrent.ConcurrentHashMap
 import java.util.{Map => JMap}
 import com.typesafe.scalalogging.LazyLogging
 import langserver.types.TextDocumentIdentifier
 import langserver.types.VersionedTextDocumentIdentifier
 import org.langmeta.io.AbsolutePath
-import org.langmeta.io.RelativePath
 import scala.meta.Source
 import org.langmeta.inputs.Input
 

--- a/metaserver/src/main/scala/scala/meta/languageserver/Formatter.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Formatter.scala
@@ -2,7 +2,6 @@ package scala.meta.languageserver
 
 import scala.language.reflectiveCalls
 
-import java.io.PrintStream
 import scala.reflect.internal.util.ScalaClassLoader.URLClassLoader
 import com.typesafe.scalalogging.LazyLogging
 import org.langmeta.io.AbsolutePath

--- a/metaserver/src/main/scala/scala/meta/languageserver/LSPLogger.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/LSPLogger.scala
@@ -1,7 +1,6 @@
 package scala.meta.languageserver
 
 import ch.qos.logback.classic.spi.ILoggingEvent
-import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.encoder.PatternLayoutEncoder
 import ch.qos.logback.core.AppenderBase
 import langserver.core.Connection

--- a/metaserver/src/main/scala/scala/meta/languageserver/Linter.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Linter.scala
@@ -16,9 +16,6 @@ import scalafix.rule.RuleCtx
 import scalafix.util.SemanticdbIndex
 import com.typesafe.scalalogging.LazyLogging
 import langserver.types.Diagnostic
-import langserver.{types => l}
-import metaconfig.ConfDecoder
-import org.langmeta.internal.io.PathIO
 import org.langmeta.io.AbsolutePath
 
 class Linter(

--- a/metaserver/src/main/scala/scala/meta/languageserver/Main.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Main.scala
@@ -4,7 +4,6 @@ import java.io.FileOutputStream
 import java.io.PrintStream
 import java.nio.file.Files
 import java.util.concurrent.Executors
-import scala.concurrent.ExecutionContext
 import scala.util.Properties
 import com.typesafe.scalalogging.LazyLogging
 import monix.execution.Scheduler

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaEnrichments.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaEnrichments.scala
@@ -40,10 +40,10 @@ object ScalametaEnrichments {
     // TODO(alexey) function inside a block/if/for/etc.?
     def isFunction: Boolean = {
       val tpeOpt: Option[Type] = tree match {
-        case d @ Decl.Val(_) => Some(d.decltpe)
-        case d @ Decl.Var(_) => Some(d.decltpe)
-        case d @ Defn.Val(_) => d.decltpe
-        case d @ Defn.Var(_) => d.decltpe
+        case d: Decl.Val => Some(d.decltpe)
+        case d: Decl.Var => Some(d.decltpe)
+        case d: Defn.Val => d.decltpe
+        case d: Defn.Var => d.decltpe
         case _ => None
       }
       tpeOpt.filter(_.is[Type.Function]).nonEmpty
@@ -52,16 +52,16 @@ object ScalametaEnrichments {
     // NOTE: we care only about descendants of Decl, Defn and Pkg[.Object] (see documentSymbols implementation)
     def symbolKind: SymbolKind = tree match {
       case f if f.isFunction => SymbolKind.Function
-      case Decl.Var(_) | Defn.Var(_) => SymbolKind.Variable
-      case Decl.Val(_) | Defn.Val(_) => SymbolKind.Constant
-      case Decl.Def(_) | Defn.Def(_) => SymbolKind.Method
-      case Decl.Type(_) | Defn.Type(_) => SymbolKind.Field
-      case Defn.Macro(_) => SymbolKind.Constructor
-      case Defn.Class(_) => SymbolKind.Class
-      case Defn.Trait(_) => SymbolKind.Interface
-      case Defn.Object(_) => SymbolKind.Module
-      case Pkg.Object(_) => SymbolKind.Namespace
-      case Pkg(_) => SymbolKind.Package
+      case _: Decl.Var | _: Defn.Var => SymbolKind.Variable
+      case _: Decl.Val | _: Defn.Val => SymbolKind.Constant
+      case _: Decl.Def | _: Defn.Def => SymbolKind.Method
+      case _: Decl.Type | _: Defn.Type => SymbolKind.Field
+      case _: Defn.Macro => SymbolKind.Constructor
+      case _: Defn.Class => SymbolKind.Class
+      case _: Defn.Trait => SymbolKind.Interface
+      case _: Defn.Object => SymbolKind.Module
+      case _: Pkg.Object => SymbolKind.Namespace
+      case _: Pkg => SymbolKind.Package
       // TODO(alexey) are these kinds useful?
       // case ??? => SymbolKind.Enum
       // case ??? => SymbolKind.String
@@ -107,7 +107,7 @@ object ScalametaEnrichments {
     def pretty: String =
       s"${pos.uri.replaceFirst(".*/", "")} [${pos.range.map(_.pretty).getOrElse("")}]"
 
-    def toLocation(implicit cwd: m.AbsolutePath): l.Location = {
+    def toLocation: l.Location = {
       l.Location(
         pos.uri,
         pos.range.get.toRange

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
@@ -7,7 +7,6 @@ import java.io.PrintStream
 import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.Paths
 import java.nio.file.SimpleFileVisitor
 import java.nio.file.FileVisitResult
 import java.nio.file.attribute.BasicFileAttributes
@@ -146,8 +145,6 @@ class ScalametaLanguageServer(
       onChangedFile(path)(_ => ())
     }
   }
-
-  private val clearIndexCacheCommand = "clearIndexCache"
 
   override def initialize(
       request: InitializeParams

--- a/metaserver/src/main/scala/scala/meta/languageserver/Uri.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Uri.scala
@@ -3,7 +3,6 @@ package scala.meta.languageserver
 import java.net.URI
 import java.nio.file.Path
 import java.nio.file.Paths
-import scala.meta.Source
 import langserver.types.TextDocumentIdentifier
 import langserver.types.VersionedTextDocumentIdentifier
 import org.langmeta.inputs.Input

--- a/metaserver/src/main/scala/scala/meta/languageserver/compiler/ScalacProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/compiler/ScalacProvider.scala
@@ -12,15 +12,12 @@ import scala.tools.nsc.reporters.StoreReporter
 import com.typesafe.scalalogging.LazyLogging
 import langserver.types.TextDocumentIdentifier
 import langserver.types.VersionedTextDocumentIdentifier
-import monix.execution.Scheduler
 import org.langmeta.inputs.Input
 
 /** Responsible for keeping fresh scalac global instances. */
 class ScalacProvider(
     serverConfig: ServerConfig
-)(implicit s: Scheduler)
-    extends LazyLogging {
-  private implicit val cwd = serverConfig.cwd
+) extends LazyLogging {
 
   def getCompiler(input: Input.VirtualFile): Option[Global] =
     getCompiler(Uri(input.path))

--- a/metaserver/src/main/scala/scala/meta/languageserver/mtags/JavaMtags.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/mtags/JavaMtags.scala
@@ -14,7 +14,6 @@ import com.thoughtworks.qdox.model.JavaField
 import com.thoughtworks.qdox.model.JavaMember
 import com.thoughtworks.qdox.model.JavaMethod
 import com.thoughtworks.qdox.model.JavaModel
-import com.thoughtworks.qdox.model.impl.DefaultJavaField
 import org.langmeta.inputs.Input
 import org.langmeta.inputs.Position
 import org.langmeta.languageserver.InputEnrichments._

--- a/metaserver/src/main/scala/scala/meta/languageserver/mtags/Mtags.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/mtags/Mtags.scala
@@ -9,11 +9,9 @@ import java.nio.file.Path
 import java.nio.file.SimpleFileVisitor
 import java.nio.file.attribute.BasicFileAttributes
 import java.text.DecimalFormat
-import java.text.NumberFormat
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.zip.ZipInputStream
-import scala.collection.GenSeq
 import scala.collection.parallel.mutable.ParArray
 import scala.meta.parsers.ParseException
 import com.thoughtworks.qdox.parser.{ParseException => QParseException}
@@ -179,14 +177,14 @@ object Mtags extends LazyLogging {
    */
   private def allClasspathFragments(
       classpath: List[AbsolutePath],
-      shouldIndex: RelativePath => Boolean = _ => true
+      shouldIndex: RelativePath => Boolean
   ): ParArray[Fragment] = {
-    var buf = ParArray.newBuilder[Fragment]
+    val buf = ParArray.newBuilder[Fragment]
     def add(fragment: Fragment): Unit = {
       if (shouldIndex(fragment.name)) buf += fragment
       else ()
     }
-    classpath.foreach { base =>
+    classpath.foreach[Any] { base =>
       def exploreJar(base: AbsolutePath): Unit = {
         val stream = Files.newInputStream(base.toNIO)
         try {

--- a/metaserver/src/main/scala/scala/meta/languageserver/providers/CompletionProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/providers/CompletionProvider.scala
@@ -4,10 +4,8 @@ import scala.collection.mutable
 import scala.meta.languageserver.compiler.Cursor
 import scala.meta.languageserver.compiler.ScalacProvider
 import scala.meta.languageserver.compiler.CompilerEnrichments._
-import scala.reflect.internal.util.Position
 import scala.tools.nsc.interactive.Global
 import com.typesafe.scalalogging.LazyLogging
-import langserver.core.Notifications
 import langserver.messages.CompletionList
 import langserver.types.CompletionItem
 import langserver.types.CompletionItemKind
@@ -22,7 +20,7 @@ object CompletionProvider extends LazyLogging {
     import compiler._
 
     def completionItemKind(r: CompletionResult#M): CompletionItemKind = {
-      if (r.sym.isPackage) CompletionItemKind.Module
+      if (r.sym.hasPackageFlag) CompletionItemKind.Module
       else if (r.sym.isPackageObject) CompletionItemKind.Module
       else if (r.sym.isModuleOrModuleClass) CompletionItemKind.Module
       else if (r.sym.isTraitOrInterface) CompletionItemKind.Interface

--- a/metaserver/src/main/scala/scala/meta/languageserver/providers/DocumentFormattingProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/providers/DocumentFormattingProvider.scala
@@ -1,12 +1,9 @@
 package scala.meta.languageserver.providers
 
 import java.nio.file.Files
-import scala.meta.languageserver.Buffers
 import scala.meta.languageserver.Formatter
-import scala.meta.languageserver.Uri
 import com.typesafe.scalalogging.LazyLogging
 import langserver.messages.DocumentFormattingResult
-import langserver.messages.TextDocumentFormattingRequest
 import langserver.types.Position
 import langserver.types.Range
 import langserver.types.TextEdit

--- a/metaserver/src/main/scala/scala/meta/languageserver/providers/DocumentHighlightProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/providers/DocumentHighlightProvider.scala
@@ -1,7 +1,6 @@
 package scala.meta.languageserver.providers
 
 import com.typesafe.scalalogging.LazyLogging
-import org.langmeta.io.AbsolutePath
 import langserver.{types => l}
 import langserver.messages.DocumentHighlightResult
 import scala.meta.languageserver.Uri

--- a/metaserver/src/main/scala/scala/meta/languageserver/providers/DocumentSymbolProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/providers/DocumentSymbolProvider.scala
@@ -6,7 +6,6 @@ import scala.meta.languageserver.Uri
 import com.typesafe.scalalogging.LazyLogging
 import langserver.messages.DocumentSymbolResult
 import langserver.{types => l}
-import org.langmeta.io.AbsolutePath
 
 object DocumentSymbolProvider extends LazyLogging {
 
@@ -36,12 +35,12 @@ object DocumentSymbolProvider extends LazyLogging {
 
         currentNode match {
           // we need to go deeper
-          case Source(_) | Template(_) => continue()
+          case _: Source | _: Template => continue()
           // add package, but don't set it as a new root
-          case Pkg(_) => addNode(); continue()
+          case _: Pkg => addNode(); continue()
           // terminal nodes: add them, but don't go inside
-          case Defn.Def(_) | Defn.Val(_) | Defn.Var(_) => addNode()
-          case Decl.Def(_) | Decl.Val(_) | Decl.Var(_) => addNode()
+          case _: Defn.Def | _: Defn.Val | _: Defn.Var => addNode()
+          case _: Decl.Def | _: Decl.Val | _: Decl.Var => addNode()
           // all other (named) types and terms can contain more nodes
           case t if t.is[Member.Type] || t.is[Member.Term] =>
             addNode(); continue(withNewRoot = true)

--- a/metaserver/src/main/scala/scala/meta/languageserver/search/InverseSymbolIndexer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/search/InverseSymbolIndexer.scala
@@ -1,7 +1,5 @@
 package scala.meta.languageserver.search
 
-import java.net.URI
-import java.nio.file.Paths
 import scala.collection.mutable
 import scala.meta.languageserver.Uri
 import scala.meta.languageserver.{index => i}

--- a/metaserver/src/main/scala/scala/meta/languageserver/search/SymbolIndex.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/search/SymbolIndex.scala
@@ -1,8 +1,5 @@
 package scala.meta.languageserver.search
 
-import java.nio.charset.StandardCharsets
-import java.nio.file.Files
-import java.nio.file.Paths
 import java.util.concurrent.ConcurrentHashMap
 import scala.meta.languageserver.Buffers
 import scala.meta.languageserver.Effects
@@ -14,24 +11,15 @@ import scala.meta.languageserver.ScalametaLanguageServer.cacheDirectory
 import scala.meta.languageserver.Uri
 import scala.meta.languageserver.storage.LevelDBMap
 import scala.meta.languageserver.{index => i}
-import `scala`.meta.languageserver.index.Position
 import `scala`.meta.languageserver.index.SymbolData
 import com.typesafe.scalalogging.LazyLogging
-import langserver.{types => l}
 import langserver.core.Notifications
-import langserver.messages.DefinitionResult
-import langserver.messages.ReferencesResult
-import langserver.messages.DocumentSymbolResult
 import org.langmeta.inputs.Input
-import org.langmeta.internal.io.FileIO
 import org.langmeta.internal.semanticdb.schema.Database
-import org.langmeta.internal.semanticdb.schema.Document
 import org.langmeta.internal.semanticdb.schema.ResolvedName
 import org.langmeta.internal.semanticdb.{schema => s}
 import org.langmeta.io.AbsolutePath
-import org.langmeta.io.RelativePath
 import org.langmeta.languageserver.InputEnrichments._
-import org.langmeta.semanticdb.Signature
 import org.langmeta.semanticdb.Symbol
 
 /**

--- a/metaserver/src/main/scala/scala/meta/languageserver/storage/LevelDBMap.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/storage/LevelDBMap.scala
@@ -2,8 +2,6 @@ package scala.meta.languageserver.storage
 
 import java.io.File
 import com.typesafe.scalalogging.LazyLogging
-import monix.execution.schedulers.TestScheduler.Task
-import monix.reactive.Observable
 import org.fusesource.leveldbjni.JniDBFactory
 import org.iq80.leveldb.DB
 import org.iq80.leveldb.DBException

--- a/metaserver/src/test/scala/tests/MegaSuite.scala
+++ b/metaserver/src/test/scala/tests/MegaSuite.scala
@@ -2,7 +2,6 @@ package tests
 
 import scala.language.experimental.macros
 
-import scala.meta.Lit
 import scala.reflect.ClassTag
 import utest.TestSuite
 import utest.Tests
@@ -20,7 +19,7 @@ import utest.ufansi.Str
  * - pretty multiline string diffing
  * - FunSuite-style test("name") { => fun }
  */
-class MegaSuite(implicit filename: sourcecode.File) extends TestSuite {
+class MegaSuite extends TestSuite {
   def beforeAll(): Unit = ()
   def afterAll(): Unit = ()
   def intercept[T: ClassTag](exprs: Unit): T = macro Asserts.interceptProxy[T]

--- a/metaserver/src/test/scala/tests/compiler/CompilerSuite.scala
+++ b/metaserver/src/test/scala/tests/compiler/CompilerSuite.scala
@@ -6,7 +6,7 @@ import scala.meta.languageserver.compiler.ScalacProvider
 import scala.tools.nsc.interactive.Global
 import tests.MegaSuite
 
-class CompilerSuite(implicit file: sourcecode.File) extends MegaSuite {
+class CompilerSuite extends MegaSuite {
   val compiler: Global = ScalacProvider.newCompiler(
     "",
     "-deprecation" ::

--- a/metaserver/src/test/scala/tests/compiler/SignatureHelpTest.scala
+++ b/metaserver/src/test/scala/tests/compiler/SignatureHelpTest.scala
@@ -1,6 +1,5 @@
 package tests.compiler
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.meta.languageserver.providers.SignatureHelpProvider
 import langserver.messages.SignatureHelpResult
 import play.api.libs.json.Json

--- a/metaserver/src/test/scala/tests/search/SymbolIndexTest.scala
+++ b/metaserver/src/test/scala/tests/search/SymbolIndexTest.scala
@@ -11,12 +11,10 @@ import scala.meta.languageserver.ServerConfig
 import scala.meta.languageserver.Uri
 import scala.meta.languageserver.search.InverseSymbolIndexer
 import scala.meta.languageserver.search.SymbolIndex
-import scala.meta.languageserver.index.SymbolData
 import scala.{meta => m}
 import langserver.{types => l}
 import langserver.messages.ClientCapabilities
 import monix.execution.schedulers.TestScheduler
-import org.langmeta.internal.io.PathIO
 import org.langmeta.io.AbsolutePath
 import org.langmeta.io.Classpath
 import org.langmeta.semanticdb.Symbol

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.5.7")
 addSbtPlugin("ch.epfl.scala" % "sbt-release-early" % "2.0.0")
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC13")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")


### PR DESCRIPTION
I haven't been diligent enough at dogfooding scalafix in my own projects, so I hope you don't mind. We already have semanticdb-scalac enabled by default, so we might as well enjoy the benefits of using scalafix :)

- remove unused locals/parameters/imports
- explicit result types for implicits
- no infer is still too noisy, missing https://github.com/scalacenter/scalafix/issues/506
- disable option.get is also too noisy due to tests and protobuf messages