### PR TITLE
Add command to reset presentation compiler

### DIFF
--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
@@ -314,6 +314,8 @@ class ScalametaLanguageServer(
           logger.info("Clearing the index cache")
           ScalametaLanguageServer.clearCacheDirectory()
         case ResetPresentationCompiler =>
+          logger.info("Resetting all compiler instances")
+          scalac.resetCompilers()
       }
   }
 

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
@@ -309,12 +309,12 @@ class ScalametaLanguageServer(
     import WorkspaceCommand._
     WorkspaceCommand
       .withNameOption(request.params.command)
-      .map {
+      .fold(logger.error(s"Unknown command ${request.params.command}")) {
         case ClearIndexCache =>
           logger.info("Clearing the index cache")
           ScalametaLanguageServer.clearCacheDirectory()
+        case ResetPresentationCompiler =>
       }
-      .getOrElse(logger.error(s"Unknown command ${request.params.command}"))
   }
 
   override def onChangeTextDocument(

--- a/metaserver/src/main/scala/scala/meta/languageserver/WorkspaceCommand.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/WorkspaceCommand.scala
@@ -9,6 +9,7 @@ sealed trait WorkspaceCommand extends EnumEntry with Uncapitalised
 case object WorkspaceCommand extends Enum[WorkspaceCommand] {
 
   case object ClearIndexCache extends WorkspaceCommand
+  case object ResetPresentationCompiler extends WorkspaceCommand
 
   val values = findValues
 

--- a/metaserver/src/main/scala/scala/meta/languageserver/compiler/ScalacProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/compiler/ScalacProvider.scala
@@ -68,8 +68,10 @@ class ScalacProvider(
     Effects.InstallPresentationCompiler
   }
 
-  def resetCompilers(): Unit = {}
-
+  def resetCompilers(): Unit =
+    compilerByConfigOrigin.values.foreach {
+      case (_, global) => global.askReset()
+    }
 }
 
 object ScalacProvider extends LazyLogging {

--- a/project/ScalametaLanguageServerPlugin.scala
+++ b/project/ScalametaLanguageServerPlugin.scala
@@ -22,22 +22,32 @@ object ScalametaLanguageServerPlugin extends AutoPlugin {
         scalametaCompilerConfig := {
           val props = new java.util.Properties()
           props.setProperty(
-            "scalacOptions",
-            scalacOptions.value.mkString(" ")
+            "sources",
+            sources.value.distinct.mkString(File.pathSeparator)
           )
           props.setProperty(
-            "dependencyClasspath",
-            dependencyClasspath.value
-              .map(_.data.toString)
+            "unmanagedSourceDirectories",
+            unmanagedSourceDirectories.value.distinct
               .mkString(File.pathSeparator)
+          )
+          props.setProperty(
+            "managedSourceDirectories",
+            managedSourceDirectories.value.distinct
+              .mkString(File.pathSeparator)
+          )
+          props.setProperty(
+            "scalacOptions",
+            scalacOptions.value.mkString(" ")
           )
           props.setProperty(
             "classDirectory",
             classDirectory.value.getAbsolutePath
           )
           props.setProperty(
-            "sources",
-            sources.value.distinct.mkString(File.pathSeparator)
+            "dependencyClasspath",
+            dependencyClasspath.value
+              .map(_.data.toString)
+              .mkString(File.pathSeparator)
           )
           val sourceJars = for {
             configurationReport <- updateClassifiers.value.configurations

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -22,6 +22,10 @@
             "command": "scalameta.clearIndexCache",
             "category": "Scalameta Language Server",
             "title": "Clear index cache"
+        }, {
+            "command": "scalameta.resetPresentationCompiler",
+            "category": "Scalameta Language Server",
+            "title": "Reset presentation compilers"
         }]
     },
     "main": "./out/extension",

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -90,7 +90,10 @@ export async function activate(context: ExtensionContext) {
     const clearIndexCacheCommand = commands.registerCommand("scalameta.clearIndexCache", async () => {
       return client.sendRequest(ExecuteCommandRequest.type, { command: "clearIndexCache" });
     });
-    context.subscriptions.push(clearIndexCacheCommand);
+    const resetPresentationCompiler = commands.registerCommand("scalameta.resetPresentationCompiler", async () => {
+      return client.sendRequest(ExecuteCommandRequest.type, { command: "resetPresentationCompiler" });
+    });
+    context.subscriptions.push(clearIndexCacheCommand, resetPresentationCompiler);
   });
 
   context.subscriptions.push(client.start(), restartServerCommand);


### PR DESCRIPTION
Previously, we didn't keep track of active presentation compilers so the first commit re-organized handling of PC instances. I tried this locally and the UX wasn't stellar, red squigglies are not refreshed and there is no notification when the PC has been reloaded, completions just suddenly start picking up the latest classpath changes. 

Note that askReload only makes the PC pick up latest classpath changes. If you add a new class in module `a` and want it to appear in a file in module `b` that depends on `a`, then you must first re-compile module `a` via sbt and then "Reload presentation compilers".