### PR TITLE
Workspace symbols

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -116,6 +116,7 @@ lazy val metaserver = project
     libraryDependencies ++= List(
       "io.github.soc" % "directories" % "5",
       "org.fusesource.leveldbjni" % "leveldbjni-all" % "1.8",
+      "me.xdrop" % "fuzzywuzzy" % "1.1.9",
       "com.lihaoyi" %% "pprint" % "0.5.3",
       "com.thoughtworks.qdox" % "qdox" % "2.0-M7", // for java mtags
       "io.get-coursier" %% "coursier" % coursier.util.Properties.version,

--- a/languageserver/src/main/scala/langserver/core/LanguageServer.scala
+++ b/languageserver/src/main/scala/langserver/core/LanguageServer.scala
@@ -24,6 +24,7 @@ class LanguageServer(inStream: InputStream, outStream: OutputStream)(implicit s:
       case ("textDocument/references", request: TextDocumentReferencesRequest) => references(request)
       case ("textDocument/signatureHelp", request: TextDocumentSignatureHelpRequest) => signatureHelp(request)
       case ("workspace/executeCommand", request: WorkspaceExecuteCommandRequest) => executeCommand(request).map(_ => ExecuteCommandResult)
+      case ("workspace/symbol", request: WorkspaceSymbolRequest) => workspaceSymbol(request)
       case ("shutdown", _: Shutdown) => shutdown()
       case c => Task.raiseError(new IllegalArgumentException(s"Unknown command $c"))
     }
@@ -72,6 +73,7 @@ class LanguageServer(inStream: InputStream, outStream: OutputStream)(implicit s:
 
   // workspace
   def executeCommand(request: WorkspaceExecuteCommandRequest): Task[Unit] = Task.now(())
+  def workspaceSymbol(request: WorkspaceSymbolRequest): Task[WorkspaceSymbolResult] = Task.now(WorkspaceSymbolResult(Nil))
 
   def onOpenTextDocument(td: TextDocumentItem): Unit = {
     logger.debug(s"openTextDocument $td")

--- a/languageserver/src/main/scala/langserver/messages/Commands.scala
+++ b/languageserver/src/main/scala/langserver/messages/Commands.scala
@@ -200,6 +200,7 @@ case class TextDocumentDocumentHighlightRequest(params: TextDocumentPositionPara
 case class TextDocumentHoverRequest(params: TextDocumentPositionParams) extends ServerCommand
 case class TextDocumentFormattingRequest(params: DocumentFormattingParams) extends ServerCommand
 case class WorkspaceExecuteCommandRequest(params: WorkspaceExecuteCommandParams) extends ServerCommand
+case class WorkspaceSymbolRequest(params: WorkspaceSymbolParams) extends ServerCommand
 
 case class Hover(contents: Seq[MarkedString], range: Option[Range]) extends ResultResponse
 object Hover {
@@ -222,7 +223,8 @@ object ServerCommand extends CommandCompanion[ServerCommand] {
     "textDocument/hover" -> valueFormat(TextDocumentHoverRequest)(_.params),
     "textDocument/documentSymbol" -> Json.format[DocumentSymbolParams],
     "textDocument/formatting" -> valueFormat(TextDocumentFormattingRequest)(_.params),
-    "workspace/executeCommand" -> valueFormat(WorkspaceExecuteCommandRequest)(_.params)
+    "workspace/executeCommand" -> valueFormat(WorkspaceExecuteCommandRequest)(_.params),
+    "workspace/symbol" -> valueFormat(WorkspaceSymbolRequest)(_.params),
   )
 
   // NOTE: this is a workaround to read `shutdown` request which doesn't have parameters (scala-json-rpc requires parameters for all requests)
@@ -304,9 +306,13 @@ case class DocumentFormattingResult(params: Seq[TextEdit]) extends ResultRespons
 case class SignatureHelpResult(signatures: Seq[SignatureInformation],
                                activeSignature: Option[Int],
                                activeParameter: Option[Int]) extends ResultResponse
-case object ExecuteCommandResult extends ResultResponse
 object SignatureHelpResult {
   implicit val format: OFormat[SignatureHelpResult] = Json.format[SignatureHelpResult]
+}
+case object ExecuteCommandResult extends ResultResponse
+case class WorkspaceSymbolResult(params: Seq[SymbolInformation]) extends ResultResponse
+object WorkspaceSymbolResult {
+  implicit val format: OFormat[WorkspaceSymbolResult] = Json.format[WorkspaceSymbolResult]
 }
 
 object ResultResponse extends ResponseCompanion[Any] {
@@ -323,6 +329,7 @@ object ResultResponse extends ResponseCompanion[Any] {
     "textDocument/documentSymbol" -> valueFormat(DocumentSymbolResult)(_.params),
     "textDocument/formatting" -> valueFormat(DocumentFormattingResult)(_.params),
     "workspace/executeCommand" -> emptyFormat[ExecuteCommandResult.type],
+    "workspace/symbol" -> valueFormat(WorkspaceSymbolResult.apply)(_.params),
     "shutdown" -> ShutdownResult.format
   )
 }

--- a/languageserver/src/main/scala/langserver/types/types.scala
+++ b/languageserver/src/main/scala/langserver/types/types.scala
@@ -176,6 +176,9 @@ object SymbolInformation {
  * The parameters of a [WorkspaceSymbolRequest](#WorkspaceSymbolRequest).
  */
 case class WorkspaceSymbolParams(query: String)
+object WorkspaceSymbolParams {
+  implicit val format: OFormat[WorkspaceSymbolParams] = Json.format[WorkspaceSymbolParams]
+}
 
 case class CodeActionContext(diagnostics: Seq[Diagnostic])
 

--- a/metaserver/src/main/scala/org/langmeta/semanticdb/SemanticdbEnrichments.scala
+++ b/metaserver/src/main/scala/org/langmeta/semanticdb/SemanticdbEnrichments.scala
@@ -1,0 +1,14 @@
+package org.langmeta.semanticdb
+
+import langserver.types.SymbolKind
+
+object SemanticdbEnrichments {
+  implicit class XtensionLongAsFlags(val flags: Long) extends HasFlags {
+    def hasOneOfFlags(flags: Long): Boolean =
+      (this.flags & flags) != 0L
+    def toSymbolKind: SymbolKind =
+      if (isClass) SymbolKind.Class
+      else if (isTrait) SymbolKind.Interface
+      else SymbolKind.Module
+  }
+}

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
@@ -44,6 +44,8 @@ import langserver.messages.TextDocumentReferencesRequest
 import langserver.messages.TextDocumentSignatureHelpRequest
 import langserver.messages.WorkspaceExecuteCommandRequest
 import langserver.messages.ExecuteCommandOptions
+import langserver.messages.WorkspaceSymbolRequest
+import langserver.messages.WorkspaceSymbolResult
 import langserver.types._
 import monix.eval.Task
 import monix.execution.Cancelable
@@ -171,7 +173,8 @@ class ScalametaLanguageServer(
       documentFormattingProvider = true,
       hoverProvider = true,
       executeCommandProvider =
-        ExecuteCommandOptions(WorkspaceCommand.values.map(_.entryName))
+        ExecuteCommandOptions(WorkspaceCommand.values.map(_.entryName)),
+      workspaceSymbolProvider = true
     )
     InitializeResult(capabilities)
   }
@@ -317,6 +320,24 @@ class ScalametaLanguageServer(
           logger.info("Resetting all compiler instances")
           scalac.resetCompilers()
       }
+  }
+
+  override def workspaceSymbol(
+      request: WorkspaceSymbolRequest
+  ): Task[WorkspaceSymbolResult] = Task {
+    logger.info(s"Workspace $request")
+    WorkspaceSymbolResult(
+      SymbolInformation(
+        name = "Banana",
+        SymbolKind.Array,
+        Location(
+          "file:///Users/ollie/dev/language-server/build.sbt",
+          Range(Position(0, 0), Position(0, 0))
+        ),
+        None
+      ) :: Nil
+    )
+
   }
 
   override def onChangeTextDocument(

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
@@ -326,18 +326,7 @@ class ScalametaLanguageServer(
       request: WorkspaceSymbolRequest
   ): Task[WorkspaceSymbolResult] = Task {
     logger.info(s"Workspace $request")
-    WorkspaceSymbolResult(
-      SymbolInformation(
-        name = "Banana",
-        SymbolKind.Array,
-        Location(
-          "file:///Users/ollie/dev/language-server/build.sbt",
-          Range(Position(0, 0), Position(0, 0))
-        ),
-        None
-      ) :: Nil
-    )
-
+    WorkspaceSymbolResult(symbolIndex.workspaceSymbols(request.params.query))
   }
 
   override def onChangeTextDocument(

--- a/metaserver/src/main/scala/scala/meta/languageserver/search/SymbolIndex.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/search/SymbolIndex.scala
@@ -6,6 +6,7 @@ import scala.meta.languageserver.ServerConfig
 import scala.meta.languageserver.index.SymbolData
 import scala.meta.languageserver.Uri
 import langserver.core.Notifications
+import langserver.types.SymbolInformation
 import org.langmeta.internal.semanticdb.{schema => s}
 import org.langmeta.io.AbsolutePath
 import org.langmeta.semanticdb.Symbol
@@ -20,6 +21,9 @@ trait SymbolIndex {
 
   /** Returns symbol references data from the index taking into account relevant alternatives */
   def referencesData(symbol: Symbol): List[SymbolData]
+
+  /** Returns symbol definitions in this workspace */
+  def workspaceSymbols(query: String): List[SymbolInformation]
 
   def indexDependencyClasspath(
       sourceJars: List[AbsolutePath]

--- a/metaserver/src/test/scala/tests/search/SymbolIndexTest.scala
+++ b/metaserver/src/test/scala/tests/search/SymbolIndexTest.scala
@@ -207,6 +207,20 @@ object SymbolIndexTest extends MegaSuite {
         )
     }
 
+    "workspace" - {
+      def checkQuery(
+          expected: String*
+      )(implicit path: utest.framework.TestPath): Unit = {
+        while (s.tickOne()) ()
+        val result = server.symbolIndex.workspaceSymbols(path.value.last)
+        val obtained = result.toIterator.map(_.name).mkString("\n")
+        assertNoDiff(obtained, expected.mkString("\n"))
+      }
+      "EmptyResult" - checkQuery()
+      "User" - checkQuery("User", "UserTest")
+      "Test" - checkQuery("UserTest")
+    }
+
     "bijection" - {
       val target = cwd.resolve("target").resolve("scala-2.12")
       val originalDatabase = {

--- a/test-workspace/src/main/scala/example/User.scala
+++ b/test-workspace/src/main/scala/example/User.scala
@@ -4,5 +4,5 @@ case class User(name: String, age: Int)
 
 object a {
   val x = "ba"
-  val y = List(1).length
+  val y = List(1, x).length
 }

--- a/test-workspace/src/main/scala/example/User.scala
+++ b/test-workspace/src/main/scala/example/User.scala
@@ -4,5 +4,5 @@ case class User(name: String, age: Int)
 
 object a {
   val x = "ba"
-  val y = List(1, x).length
+  val y = List(1).length
 }


### PR DESCRIPTION
I found this functionality desperately missing while trying out the plugin. The current implementation builds on top of our existing semanticdb symbol index.

![screen shot 2017-12-19 at 10 11 31](https://user-images.githubusercontent.com/1408093/34149848-c3811c3e-e4a6-11e7-9d67-37e20eb80c6a.png)
![screen shot 2017-12-19 at 10 11 46](https://user-images.githubusercontent.com/1408093/34149849-c39c3992-e4a6-11e7-9918-188a0d356d0f.png)

I left two improvements for future PRs
- https://github.com/scalameta/language-server/issues/139 - semanticdb-free indexing
- https://github.com/scalameta/language-server/issues/138 - better fuzzy search