### PR TITLE
Index class primary constructor parameters

### DIFF
--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
@@ -316,6 +316,10 @@ class ScalametaLanguageServer(
         case ClearIndexCache =>
           logger.info("Clearing the index cache")
           ScalametaLanguageServer.clearCacheDirectory()
+          symbolIndex.clearIndex()
+          scalac.allCompilerConfigs.foreach(
+            config => symbolIndex.indexDependencyClasspath(config.sourceJars)
+          )
         case ResetPresentationCompiler =>
           logger.info("Resetting all compiler instances")
           scalac.resetCompilers()

--- a/metaserver/src/main/scala/scala/meta/languageserver/compiler/ScalacProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/compiler/ScalacProvider.scala
@@ -55,6 +55,8 @@ class ScalacProvider(
   private val compilerByConfigOrigin =
     mutable.Map.empty[AbsolutePath, (CompilerConfig, Global)]
   private val compilerByPath = mutable.Map.empty[Uri, Global]
+  def allCompilerConfigs: Iterable[CompilerConfig] =
+    compilerByConfigOrigin.values.map(_._1)
   def loadNewCompilerGlobals(
       config: CompilerConfig
   ): Effects.InstallPresentationCompiler = {

--- a/metaserver/src/main/scala/scala/meta/languageserver/mtags/MtagsIndexer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/mtags/MtagsIndexer.scala
@@ -3,7 +3,6 @@ package scala.meta.languageserver.mtags
 import scala.meta.Name
 import scala.meta.Term
 import scala.meta.PACKAGE
-import scala.meta.Type
 import scala.meta.languageserver.ScalametaEnrichments._
 import org.langmeta.internal.semanticdb.schema.Denotation
 import org.langmeta.internal.semanticdb.schema.ResolvedName
@@ -37,9 +36,11 @@ trait MtagsIndexer {
     addSignature(Signature.Term(name), pos, flags)
   def term(name: Term.Name, flags: Long): Unit =
     addSignature(Signature.Term(name.value), name.pos, flags)
+  def param(name: Name, flags: Long): Unit =
+    addSignature(Signature.TermParameter(name.value), name.pos, flags)
   def tpe(name: String, pos: m.Position, flags: Long): Unit =
     addSignature(Signature.Type(name), pos, flags)
-  def tpe(name: Type.Name, flags: Long): Unit =
+  def tpe(name: Name, flags: Long): Unit =
     addSignature(Signature.Type(name.value), name.pos, flags)
   def pkg(ref: Term): Unit = ref match {
     case Name(name) =>

--- a/metaserver/src/main/scala/scala/meta/languageserver/mtags/ScalaMtags.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/mtags/ScalaMtags.scala
@@ -32,7 +32,11 @@ object ScalaMtags {
             for {
               params <- t.ctor.paramss
               param <- params
-            } withOwner() { super.param(param.name, VAL) }
+            } withOwner() {
+              // TODO(olafur) More precise flags, we add VAL here blindly even if
+              // it's not a val, it might even be a var!
+              super.param(param.name, VAL | PARAM)
+            }
             continue()
           case t: Defn.Trait => tpe(t.name, TRAIT); continue()
           case t: Defn.Object => term(t.name, OBJECT); continue()

--- a/metaserver/src/main/scala/scala/meta/languageserver/mtags/ScalaMtags.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/mtags/ScalaMtags.scala
@@ -27,7 +27,13 @@ object ScalaMtags {
             term(t.name, PACKAGEOBJECT);
             term("package", t.name.pos, OBJECT);
             continue()
-          case t: Defn.Class => tpe(t.name, CLASS); continue()
+          case t: Defn.Class =>
+            tpe(t.name, CLASS)
+            for {
+              params <- t.ctor.paramss
+              param <- params
+            } withOwner() { super.param(param.name, VAL) }
+            continue()
           case t: Defn.Trait => tpe(t.name, TRAIT); continue()
           case t: Defn.Object => term(t.name, OBJECT); continue()
           case t: Defn.Type => tpe(t.name, TYPE); stop()

--- a/metaserver/src/main/scala/scala/meta/languageserver/search/InMemorySymbolIndex.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/search/InMemorySymbolIndex.scala
@@ -215,4 +215,7 @@ class InMemorySymbolIndex(
       }
     result.toList
   }
+
+  def clearIndex(): Unit = indexedJars.clear()
+
 }

--- a/metaserver/src/main/scala/scala/meta/languageserver/search/SymbolIndex.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/search/SymbolIndex.scala
@@ -31,6 +31,10 @@ trait SymbolIndex {
 
   /** Register this Database to symbol indexer. */
   def indexDatabase(document: s.Database): Effects.IndexSemanticdb
+
+  /** Remove any persisted files from index returning to a clean start */
+  def clearIndex(): Unit
+
 }
 
 object SymbolIndex {

--- a/metaserver/src/test/scala/tests/mtags/ScalaMtagsTest.scala
+++ b/metaserver/src/test/scala/tests/mtags/ScalaMtagsTest.scala
@@ -151,8 +151,8 @@ object ScalaMtagsTest extends BaseMtagsTest {
       |
       |Symbols:
       |_root_.A# => class A
-      |_root_.A#(a) => val a
-      |_root_.A#(b) => val b
+      |_root_.A#(a) => val param a
+      |_root_.A#(b) => val param b
       |""".stripMargin
   )
 }

--- a/metaserver/src/test/scala/tests/mtags/ScalaMtagsTest.scala
+++ b/metaserver/src/test/scala/tests/mtags/ScalaMtagsTest.scala
@@ -136,4 +136,23 @@ object ScalaMtagsTest extends BaseMtagsTest {
       |_root_.Tpe#N# => type N
     """.stripMargin
   )
+
+  check(
+    "class-field.scala",
+    "case class A(a: Int, b: String)",
+    """
+      |Language:
+      |Scala212
+      |
+      |Names:
+      |[11..12): A <= _root_.A#
+      |[13..14): a <= _root_.A#(a)
+      |[21..22): b <= _root_.A#(b)
+      |
+      |Symbols:
+      |_root_.A# => class A
+      |_root_.A#(a) => val a
+      |_root_.A#(b) => val b
+      |""".stripMargin
+  )
 }


### PR DESCRIPTION
Fixes #134. I noticed that the new "clear index" command doesn't cleanup the in-memory `indexedJars` map forcing me to restart the server to re-index.

This is my first PR developed (almost) entirely through vscode 🎉 