### PR TITLE
Fixed location of the plugin for 0.13

### DIFF
--- a/BETA.md
+++ b/BETA.md
@@ -13,7 +13,7 @@ an sbt plugin. This plugin is currently not published, so you will need to copy 
 Here's the source of the plugin: https://github.com/scalameta/language-server/blob/master/project/ScalametaLanguageServerPlugin.scala
 
 Copy the source to either (depending on your sbt version):
-- (sbt 0.13) `~/.sbt/0.13/plugins/project/ScalametaLanguageServerPlugin.scala`
+- (sbt 0.13) `~/.sbt/0.13/plugins/ScalametaLanguageServerPlugin.scala`
 - (sbt 1.0) `~/.sbt/1.0/plugins/ScalametaLanguageServerPlugin.scala`
 
 ## Step 2 - build the VSCode extension


### PR DESCRIPTION
The `project` part seems to be not needed