### PR TITLE
Implement edit-distance for stale semanticdbs.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -114,6 +114,7 @@ lazy val metaserver = project
     ),
     buildInfoPackage := "scala.meta.languageserver.internal",
     libraryDependencies ++= List(
+      "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0",
       "io.github.soc" % "directories" % "5",
       "org.fusesource.leveldbjni" % "leveldbjni-all" % "1.8",
       "me.xdrop" % "fuzzywuzzy" % "1.1.9",

--- a/metaserver/src/main/scala/org/langmeta/languageserver/InputEnrichments.scala
+++ b/metaserver/src/main/scala/org/langmeta/languageserver/InputEnrichments.scala
@@ -34,6 +34,10 @@ object InputEnrichments {
       )
     }
 
+    /** Returns offset position with end == start == offset */
+    def toOffsetPosition(offset: Int): Position =
+      Position.Range(input, offset, offset)
+
     /** Returns a scala.meta.Position from an index range. */
     def toPosition(range: l.Range): Position = {
       toPosition(

--- a/metaserver/src/main/scala/org/langmeta/languageserver/InputEnrichments.scala
+++ b/metaserver/src/main/scala/org/langmeta/languageserver/InputEnrichments.scala
@@ -6,8 +6,24 @@ import scala.meta.languageserver.{index => i}
 import langserver.{types => l}
 
 object InputEnrichments {
+  implicit class XtensionPositionOffset(val pos: Position) extends AnyVal {
+    def caret: String = pos match {
+      case Position.None => "<none>"
+      case _ => " " * pos.startColumn + "^"
+    }
+    def path: String = pos match {
+      case Position.None => "<none>"
+      case _ => s"${pos.input.syntax}:${pos.startLine + 1}:${pos.startColumn}"
+    }
+    def lineContent: String = pos match {
+      case r: Position.Range =>
+        val start = pos.start - pos.startColumn
+        val end = pos.input.lineToOffset(pos.startLine + 1) - 1
+        r.copy(start = start, end = end).text
+      case _ => "<none>"
+    }
+  }
   implicit class XtensionInputOffset(val input: Input) extends AnyVal {
-
     def toIndexRange(start: Int, end: Int): i.Range = {
       val pos = Position.Range(input, start, end)
       i.Range(

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaEnrichments.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaEnrichments.scala
@@ -1,15 +1,15 @@
 package scala.meta.languageserver
 
+import java.net.URI
+import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Paths
-import java.nio.charset.StandardCharsets
-import java.net.URI
+import scala.meta.languageserver.{index => i}
 import scala.{meta => m}
 import langserver.types.SymbolKind
 import langserver.{types => l}
-import scala.meta.languageserver.{index => i}
-import org.langmeta.io.AbsolutePath
 import org.langmeta.internal.io.FileIO
+import org.langmeta.io.AbsolutePath
 
 // Extension methods for convenient reuse of data conversions between
 // scala.meta._ and language.types._
@@ -141,6 +141,12 @@ object ScalametaEnrichments {
     def toLanguageServerUri: String = "file:" + path.toString()
   }
   implicit class XtensionPositionRangeLSP(val pos: m.Position) extends AnyVal {
+    def toIndexRange: i.Range = i.Range(
+      startLine = pos.startLine,
+      startColumn = pos.startColumn,
+      endLine = pos.endLine,
+      endColumn = pos.endColumn
+    )
     def contains(offset: Int): Boolean =
       if (pos.start == pos.end) pos.end == offset
       else {
@@ -279,17 +285,16 @@ object ScalametaEnrichments {
     }
   }
 
-  implicit class XtensionSymbolData(val symbolData: i.SymbolData)
-      extends AnyVal {
+  implicit class XtensionSymbolData(val data: i.SymbolData) extends AnyVal {
 
     /** Returns reference positions for the given symbol index data
      * @param withDefinition if set to `true` will include symbol definition location
      */
     def referencePositions(withDefinition: Boolean): Set[i.Position] = {
-      val defPosition = if (withDefinition) symbolData.definition else None
+      val defPosition = if (withDefinition) data.definition else None
 
       val refPositions = for {
-        (uri, rangeSet) <- symbolData.references
+        (uri, rangeSet) <- data.references
         range <- rangeSet.ranges
       } yield i.Position(uri, Some(range))
 

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaEnrichments.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaEnrichments.scala
@@ -121,6 +121,12 @@ object ScalametaEnrichments {
       l.Position(line = range.startLine, character = range.startColumn),
       l.Position(line = range.endLine, character = range.endColumn)
     )
+    def contains(pos: m.Position): Boolean = {
+      range.startLine <= pos.startLine &&
+      range.startColumn <= pos.startColumn &&
+      range.endLine >= pos.endLine &&
+      range.endColumn >= pos.endColumn
+    }
     def contains(line: Int, column: Int): Boolean = {
       range.startLine <= line &&
       range.startColumn <= column &&
@@ -135,6 +141,12 @@ object ScalametaEnrichments {
     def toLanguageServerUri: String = "file:" + path.toString()
   }
   implicit class XtensionPositionRangeLSP(val pos: m.Position) extends AnyVal {
+    def contains(offset: Int): Boolean =
+      if (pos.start == pos.end) pos.end == offset
+      else {
+        pos.start <= offset &&
+        pos.end > offset
+      }
     def location: String =
       s"${pos.input.syntax}:${pos.startLine}:${pos.startColumn}"
     def toRange: l.Range = l.Range(

--- a/metaserver/src/main/scala/scala/meta/languageserver/providers/DefinitionProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/providers/DefinitionProvider.scala
@@ -17,12 +17,7 @@ object DefinitionProvider extends LazyLogging {
       tempSourcesDir: AbsolutePath
   ): DefinitionResult = {
     val locations = for {
-      symbol <- symbolIndex.findSymbol(
-        uri,
-        position.line,
-        position.character
-      )
-      data <- symbolIndex.definitionData(symbol)
+      data <- symbolIndex.findDefinition(uri, position.line, position.character)
       pos <- data.definition
       _ = logger.info(s"Found definition ${pos.pretty} ${data.symbol}")
     } yield pos.toLocation.toNonJar(tempSourcesDir)

--- a/metaserver/src/main/scala/scala/meta/languageserver/providers/DocumentHighlightProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/providers/DocumentHighlightProvider.scala
@@ -16,10 +16,7 @@ object DocumentHighlightProvider extends LazyLogging {
   ): DocumentHighlightResult = {
     logger.info(s"Document highlight in $uri")
     val locations = for {
-      symbol <- symbolIndex
-        .findSymbol(uri, position.line, position.character)
-        .toList
-      data <- symbolIndex.referencesData(symbol)
+      data <- symbolIndex.findReferences(uri, position.line, position.character)
       _ = logger.info(s"Highlighting symbol `${data.name}: ${data.signature}`")
       pos <- data.referencePositions(withDefinition = true)
       if pos.uri == uri.value

--- a/metaserver/src/main/scala/scala/meta/languageserver/providers/ReferencesProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/providers/ReferencesProvider.scala
@@ -16,10 +16,7 @@ object ReferencesProvider extends LazyLogging {
       context: l.ReferenceContext
   ): ReferencesResult = {
     val locations = for {
-      symbol <- symbolIndex
-        .findSymbol(uri, position.line, position.character)
-        .toList
-      data <- symbolIndex.referencesData(symbol)
+      data <- symbolIndex.findReferences(uri, position.line, position.character)
       pos <- data.referencePositions(context.includeDeclaration)
       _ = logger.info(s"Found reference ${pos.pretty} ${data.symbol}")
     } yield pos.toLocation

--- a/metaserver/src/main/scala/scala/meta/languageserver/search/BinarySearch.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/search/BinarySearch.scala
@@ -1,0 +1,28 @@
+package scala.meta.languageserver.search
+
+import scala.annotation.tailrec
+
+object BinarySearch {
+  sealed trait ComparisonResult
+  case object Greater extends ComparisonResult
+  case object Equal extends ComparisonResult
+  case object Smaller extends ComparisonResult
+
+  def array[T](
+      array: Array[T],
+      matches: T => ComparisonResult
+  ): Option[T] = {
+    @tailrec def loop(lo: Int, hi: Int): Option[T] =
+      if (lo > hi) None
+      else {
+        val mid = lo + (hi - lo) / 2
+        val curr = array(mid)
+        matches(curr) match {
+          case Greater => loop(lo, mid - 1)
+          case Equal => Some(curr)
+          case Smaller => loop(mid + 1, hi)
+        }
+      }
+    loop(0, array.length - 1)
+  }
+}

--- a/metaserver/src/main/scala/scala/meta/languageserver/search/BinarySearch.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/search/BinarySearch.scala
@@ -8,16 +8,31 @@ object BinarySearch {
   case object Equal extends ComparisonResult
   case object Smaller extends ComparisonResult
 
+  /**
+   * Binary search using a custom compare function.
+   *
+   * scala.util.Searching does not support the ability to search an IndexedSeq
+   * by a custom mapping function, you must search by an element of the same
+   * type as the elements of the Seq.
+   *
+   * @param array Must be sorted according to compare function so that for all
+   *              i > j, compare(array(i), array(i)) == Greater.
+   * @param compare Callback used at every guess index to determine whether
+   *                the search element has been found, or whether to search
+   *                above or below the guess index.
+   * @return The first element where compare(element) == Equal. There is no guarantee
+   *         which element is chosen if many elements return Equal.
+   */
   def array[T](
       array: Array[T],
-      matches: T => ComparisonResult
+      compare: T => ComparisonResult
   ): Option[T] = {
     @tailrec def loop(lo: Int, hi: Int): Option[T] =
       if (lo > hi) None
       else {
         val mid = lo + (hi - lo) / 2
         val curr = array(mid)
-        matches(curr) match {
+        compare(curr) match {
           case Greater => loop(lo, mid - 1)
           case Equal => Some(curr)
           case Smaller => loop(mid + 1, hi)

--- a/metaserver/src/main/scala/scala/meta/languageserver/search/MatchingToken.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/search/MatchingToken.scala
@@ -1,0 +1,9 @@
+package scala.meta.languageserver.search
+
+import scala.meta.Token
+
+/** A pair of tokens that align with each other across two different files */
+case class MatchingToken(original: Token, revised: Token) {
+  override def toString: String =
+    s"${original.structure} <-> ${revised.structure}"
+}

--- a/metaserver/src/main/scala/scala/meta/languageserver/search/TokenEditDistance.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/search/TokenEditDistance.scala
@@ -3,31 +3,119 @@ package scala.meta.languageserver.search
 import scala.annotation.tailrec
 import scala.meta._
 import scala.meta.languageserver.ScalametaEnrichments._
+import scala.meta.languageserver.{index => i}
 import com.typesafe.scalalogging.LazyLogging
 import difflib._
 import difflib.myers.Equalizer
+import org.langmeta.languageserver.InputEnrichments._
+
+sealed trait EmptyResult
+object EmptyResult {
+  case object Unchanged extends EmptyResult
+  case object NoMatch extends EmptyResult
+  def unchanged: Either[EmptyResult, Position] = Left(Unchanged)
+  def noMatch: Either[EmptyResult, Position] = Left(NoMatch)
+}
 
 /** Helper to map between position between two similar strings. */
-class TokenEditDistance private (matching: Array[MatchingToken]) {
+final class TokenEditDistance private (matching: Array[MatchingToken]) {
+  private val isEmpty: Boolean = matching.length == 0
+
+  private val ThisUri: String = originalInput match {
+    case Input.VirtualFile(uri, _) => uri
+    case _ => originalInput.syntax
+  }
+  private def originalInput: Input =
+    if (isEmpty) Input.None
+    else matching(0).original.input
+
+  private def revisedInput: Input =
+    if (isEmpty) Input.None
+    else matching(0).revised.input
+
+  def toRevised(
+      originalLine: Int,
+      originalColumn: Int
+  ): Either[EmptyResult, Position] = {
+    toRevised(originalInput.toOffset(originalLine, originalColumn))
+  }
 
   /** Convert from offset in original string to offset in revised string */
-  def toRevisedPosition(originalOffset: Int): Option[Token] = {
-    BinarySearch
-      .array[MatchingToken](
-        matching,
-        mt => compare(mt.original.pos, originalOffset)
-      )
-      .map(_.revised)
+  def toRevised(originalOffset: Int): Either[EmptyResult, Position] = {
+    if (isEmpty) EmptyResult.unchanged
+    else {
+      BinarySearch
+        .array[MatchingToken](
+          matching,
+          mt => compare(mt.original.pos, originalOffset)
+        )
+        .fold(EmptyResult.noMatch)(m => Right(m.revised.pos))
+    }
+  }
+
+  private object RevisedRange {
+    def unapply(range: i.Range): Option[i.Range] =
+      toRevised(range.startLine, range.startColumn) match {
+        case Left(EmptyResult.NoMatch) => None
+        case Left(EmptyResult.Unchanged) => Some(range)
+        case Right(newPos) => Some(newPos.toIndexRange)
+      }
+  }
+
+  /** Convert the reference positions to match the revised input. */
+  def toRevisedReferences(data: i.SymbolData): i.SymbolData = {
+    val referencesAdjusted = data.references.get(ThisUri) match {
+      case Some(i.Ranges(ranges)) =>
+        val newRanges = ranges.collect { case RevisedRange(range) => range }
+        val newData = data.copy(
+          references = data.references + (ThisUri -> i.Ranges(newRanges))
+        )
+        newData
+      case _ => data
+    }
+    toRevisedDefinition(referencesAdjusted)
+  }
+
+  /** Convert the definition position to match the revised input. */
+  def toRevisedDefinition(data: i.SymbolData): i.SymbolData = {
+    data.definition match {
+      case Some(i.Position(ThisUri, Some(range))) =>
+        toRevised(range.startLine, range.startColumn) match {
+          case Left(EmptyResult.NoMatch) => data.copy(definition = None)
+          case Left(EmptyResult.Unchanged) => data
+          case Right(newPos) =>
+            val newData = data.copy(
+              definition = Some(
+                i.Position(
+                  ThisUri,
+                  Some(newPos.toIndexRange)
+                )
+              )
+            )
+            newData
+        }
+      case _ => data
+    }
+  }
+
+  def toOriginal(
+      revisedLine: Int,
+      revisedColumn: Int
+  ): Either[EmptyResult, Position] = {
+    toOriginal(revisedInput.toOffset(revisedLine, revisedColumn))
   }
 
   /** Convert from offset in revised string to offset in original string */
-  def toOriginalOffset(revisedOffset: Int): Option[Token] = {
-    BinarySearch
-      .array[MatchingToken](
-        matching,
-        mt => compare(mt.revised.pos, revisedOffset)
-      )
-      .map(_.original)
+  def toOriginal(revisedOffset: Int): Either[EmptyResult, Position] = {
+    if (isEmpty) EmptyResult.unchanged
+    else {
+      BinarySearch
+        .array[MatchingToken](
+          matching,
+          mt => compare(mt.revised.pos, revisedOffset)
+        )
+        .fold(EmptyResult.noMatch)(m => Right(m.original.pos))
+    }
   }
 
   private def compare(
@@ -41,6 +129,8 @@ class TokenEditDistance private (matching: Array[MatchingToken]) {
 }
 
 object TokenEditDistance extends LazyLogging {
+
+  lazy val empty: TokenEditDistance = new TokenEditDistance(Array.empty)
 
   /**
    * Build utility to map offsets between two slightly different strings.

--- a/metaserver/src/main/scala/scala/meta/languageserver/search/TokenEditDistance.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/search/TokenEditDistance.scala
@@ -52,7 +52,7 @@ object TokenEditDistance extends LazyLogging {
    */
   def apply(original: Tokens, revised: Tokens): TokenEditDistance = {
     val buffer = Array.newBuilder[MatchingToken]
-    buffer.sizeHint(original.length)
+    buffer.sizeHint(math.max(original.length, revised.length))
     @tailrec
     def loop(
         i: Int,

--- a/metaserver/src/main/scala/scala/meta/languageserver/search/TokenEditDistance.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/search/TokenEditDistance.scala
@@ -1,0 +1,120 @@
+package scala.meta.languageserver.search
+
+import scala.meta._
+import scala.meta.languageserver.ScalametaEnrichments._
+import com.typesafe.scalalogging.LazyLogging
+import difflib._
+import difflib.myers.Equalizer
+
+/** Helper to map between position between two similar strings. */
+class TokenEditDistance private (matching: Array[MatchingToken]) {
+
+  /** Convert from offset in original string to offset in revised string */
+  def toRevisedPosition(originalOffset: Int): Option[Token] = {
+    BinarySearch
+      .array[MatchingToken](
+        matching,
+        mt => compare(mt.original.pos, originalOffset)
+      )
+      .map(_.revised)
+  }
+
+  /** Convert from offset in revised string to offset in original string */
+  def toOriginalOffset(revisedOffset: Int): Option[Token] = {
+    BinarySearch
+      .array[MatchingToken](
+        matching,
+        mt => compare(mt.revised.pos, revisedOffset)
+      )
+      .map(_.original)
+  }
+
+  private def compare(
+      pos: Position,
+      offset: Int
+  ): BinarySearch.ComparisonResult =
+    if (pos.contains(offset)) BinarySearch.Equal
+    else if (pos.end <= offset) BinarySearch.Smaller
+    else BinarySearch.Greater
+
+}
+
+object TokenEditDistance extends LazyLogging {
+
+  /**
+   * Build utility to map offsets between two slightly different strings.
+   *
+   * @param original The original snapshot of a string, for example the latest
+   *                 semanticdb snapshot.
+   * @param revised The current snapshot of a string, for example open buffer
+   *                in an editor.
+   */
+  def apply(original: Tokens, revised: Tokens): TokenEditDistance = {
+    val buffer = Array.newBuilder[MatchingToken]
+    buffer.sizeHint(original.length)
+    def loop(
+        i: Int,
+        j: Int,
+        ds: List[Delta[Token]]
+    ): Unit = {
+      def increment(): Unit = loop(i + 1, j + 1, ds)
+      val isDone: Boolean =
+        i >= original.length ||
+          j >= revised.length
+      if (isDone) ()
+      else {
+        val o = original(i)
+        val r = revised(j)
+        if (TokenEqualizer.equals(o, r)) {
+          buffer += MatchingToken(o, r)
+          increment()
+        } else {
+          ds match {
+            case Nil => increment()
+            case delta :: tail =>
+              loop(
+                i + delta.getOriginal.size(),
+                j + delta.getRevised.size(),
+                tail
+              )
+          }
+        }
+      }
+    }
+    val deltas = {
+      import scala.collection.JavaConverters._
+      DiffUtils
+        .diff(original.asJava, revised.asJava, TokenEqualizer)
+        .getDeltas
+        .iterator()
+        .asScala
+        .toList
+    }
+    loop(0, 0, deltas)
+    new TokenEditDistance(buffer.result())
+  }
+
+  def apply(
+      originalInput: Input,
+      revisedInput: Input
+  ): Option[TokenEditDistance] = {
+    for {
+      revised <- revisedInput.tokenize.toOption
+      original <- {
+        if (originalInput == revisedInput) Some(revised)
+        else originalInput.tokenize.toOption
+      }
+    } yield apply(original, revised)
+  }
+
+  def apply(original: String, revised: String): Option[TokenEditDistance] =
+    apply(Input.String(original), Input.String(revised))
+
+  /** Compare tokens only by their text and token category. */
+  private object TokenEqualizer extends Equalizer[Token] {
+    override def equals(original: Token, revised: Token): Boolean =
+      original.productPrefix == revised.productPrefix &&
+        original.pos.text == revised.pos.text
+  }
+
+}

--- a/metaserver/src/test/scala/tests/search/SymbolIndexTest.scala
+++ b/metaserver/src/test/scala/tests/search/SymbolIndexTest.scala
@@ -33,6 +33,7 @@ object SymbolIndexTest extends MegaSuite {
       .resolve("example")
       .resolve("User.scala")
     val UserUri = Uri(User)
+    val UserReferenceLine = 3
 
     val UserTest = cwd
       .resolve("src")
@@ -149,7 +150,7 @@ object SymbolIndexTest extends MegaSuite {
 
     "definition" - {
       "<<User>>(...)" -
-        assertSymbolDefinition(3, 17)(
+        assertSymbolDefinition(path.UserReferenceLine, 17)(
           "_root_.a.User.",
           "_root_.a.User#"
         )
@@ -257,6 +258,16 @@ object SymbolIndexTest extends MegaSuite {
         case _ =>
           fail(s"Unsupported index ${index.getClass}")
       }
+    }
+
+    "edit-distance" - {
+      val user = path.UserTestUri.toInput(server.buffers)
+      val newUser = user.copy(value = "// leading comment\n" + user.value)
+      server.buffers.changed(newUser)
+      assertSymbolDefinition(path.UserReferenceLine + 1, 17)(
+        "_root_.a.User.",
+        "_root_.a.User#"
+      )
     }
   }
 

--- a/metaserver/src/test/scala/tests/search/SymbolIndexTest.scala
+++ b/metaserver/src/test/scala/tests/search/SymbolIndexTest.scala
@@ -74,7 +74,7 @@ object SymbolIndexTest extends MegaSuite {
     def assertSymbolFound(line: Int, column: Int)(
         expected: String
     ): Symbol = {
-      val symbol = index
+      val (symbol, _) = index
         .findSymbol(path.UserTestUri, line, column)
         .getOrElse(
           fail(
@@ -114,7 +114,7 @@ object SymbolIndexTest extends MegaSuite {
     )(
         expected: l.Location*
     ): Unit = {
-      val symbol = index
+      val (symbol, _) = index
         .findSymbol(path.UserTestUri, line, column)
         .getOrElse(
           fail(

--- a/metaserver/src/test/scala/tests/search/TokenEditDistanceTest.scala
+++ b/metaserver/src/test/scala/tests/search/TokenEditDistanceTest.scala
@@ -1,0 +1,126 @@
+package tests.search
+
+import scala.meta.languageserver.ScalametaEnrichments._
+import scala.meta.languageserver.search.TokenEditDistance
+import org.langmeta.inputs.Input
+import org.langmeta.inputs.Position
+import org.langmeta.languageserver.InputEnrichments._
+import tests.MegaSuite
+
+object TokenEditDistanceTest extends MegaSuite {
+  def check(
+      name: String,
+      revised: String,
+      original: String,
+      expected: String,
+      keyword: String = "List"
+  ): Unit = {
+    test(name) {
+      val input = Input.VirtualFile(name + "-original", original)
+      val edit = TokenEditDistance(original, revised).get
+      val offset = revised.indexOf(keyword)
+      val obtained = edit
+        .toOriginalOffset(offset)
+        .map { originalOffset =>
+          val pos =
+            Position.Range(input, originalOffset.start, originalOffset.end)
+          val reverse = edit.toRevisedPosition(originalOffset.start).get
+          assert(reverse.pos.contains(offset))
+          s"""|${pos.lineContent}
+              |${pos.caret}""".stripMargin
+        }
+        .getOrElse("<none>")
+      assertNoDiff(obtained, expected)
+    }
+  }
+
+  check(
+    "insert",
+    revised = """
+                |object a {
+                |  "msg".substrin
+                |  List(1)
+                |}""".stripMargin,
+    original = """
+                 |object a {
+                 |  List(1) // <--
+                 |}
+    """.stripMargin,
+    expected = """
+                 |  List(1) // <--
+                 |  ^
+                 |""".stripMargin,
+  )
+
+  check(
+    "change",
+    revised = """
+                |object a {
+                |  "msg".substrin
+                |  List(1)
+                |}""".stripMargin,
+    original = """
+                 |object a {
+                 |  this.changed()
+                 |  List(1) // <--
+                 |}
+    """.stripMargin,
+    expected = """
+                 |  List(1) // <--
+                 |  ^
+                 |""".stripMargin,
+  )
+
+  check(
+    "delete",
+    revised = """
+                |object a {
+                |  List(1)
+                |}""".stripMargin,
+    original = """
+                 |object a {
+                 |  remove(this)
+                 |  List(1) // <--
+                 |}
+    """.stripMargin,
+    expected = """
+                 |  List(1) // <--
+                 |  ^
+                 |""".stripMargin,
+  )
+
+  check(
+    "none",
+    revised = """
+                |object a {
+                |  List(1)
+                |}""".stripMargin,
+    original = """
+                 |object a {
+                 |  Something()
+                 |}
+    """.stripMargin,
+    expected = "<none>",
+  )
+
+  check(
+    "moved",
+    revised = """
+                |object a {
+                |  def foo = {
+                |    println(1)
+                |  }
+                |  List(1)
+                |}""".stripMargin,
+    original = """
+                 |object a {
+                 |  List(1)
+                 |  def foo = {
+                 |    Fuz(1)
+                 |  }
+                 |}
+               """.stripMargin,
+    expected = "<none>",
+  )
+
+}

--- a/metaserver/src/test/scala/tests/search/TokenEditDistanceTest.scala
+++ b/metaserver/src/test/scala/tests/search/TokenEditDistanceTest.scala
@@ -2,8 +2,6 @@ package tests.search
 
 import scala.meta.languageserver.ScalametaEnrichments._
 import scala.meta.languageserver.search.TokenEditDistance
-import org.langmeta.inputs.Input
-import org.langmeta.inputs.Position
 import org.langmeta.languageserver.InputEnrichments._
 import tests.MegaSuite
 
@@ -16,16 +14,13 @@ object TokenEditDistanceTest extends MegaSuite {
       keyword: String = "List"
   ): Unit = {
     test(name) {
-      val input = Input.VirtualFile(name + "-original", original)
       val edit = TokenEditDistance(original, revised).get
       val offset = revised.indexOf(keyword)
       val obtained = edit
-        .toOriginalOffset(offset)
-        .map { originalOffset =>
-          val pos =
-            Position.Range(input, originalOffset.start, originalOffset.end)
-          val reverse = edit.toRevisedPosition(originalOffset.start).get
-          assert(reverse.pos.contains(offset))
+        .toOriginal(offset)
+        .map { pos =>
+          val Right(reverse) = edit.toRevised(pos.start)
+          assert(reverse.contains(offset))
           s"""|${pos.lineContent}
               |${pos.caret}""".stripMargin
         }


### PR DESCRIPTION
Fixes #130. We currently only use this new feature for go-to-definition.
It only works if the definition is in another file with up-to-date semanticdb, otherwise stale positions are used for the definition. We should follow-up by using it for references as well.
I wanted to open this PR before it gets any bigger.
Hover will also benefit from this PR once we move away from the PC for
hover.