### PR TITLE
Implement textDocument/rename for local symbols.

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -3,6 +3,7 @@ align = none
 docstrings = javadoc
 danglingParentheses = true
 assumeStandardLibraryStripMargin = true
+binPack.literalsExclude = ["Term.Name"]
 onTestFailure = """
 To fix this problem:
 1. run ./bin/scalafmt from the project root directory

--- a/languageserver/src/main/scala/langserver/core/LanguageServer.scala
+++ b/languageserver/src/main/scala/langserver/core/LanguageServer.scala
@@ -22,6 +22,7 @@ class LanguageServer(inStream: InputStream, outStream: OutputStream)(implicit s:
       case ("textDocument/formatting", request: TextDocumentFormattingRequest) => formatting(request)
       case ("textDocument/hover", request: TextDocumentHoverRequest) => hover(request)
       case ("textDocument/references", request: TextDocumentReferencesRequest) => references(request)
+      case ("textDocument/rename", request: TextDocumentRenameRequest) => rename(request)
       case ("textDocument/signatureHelp", request: TextDocumentSignatureHelpRequest) => signatureHelp(request)
       case ("workspace/executeCommand", request: WorkspaceExecuteCommandRequest) => executeCommand(request).map(_ => ExecuteCommandResult)
       case ("workspace/symbol", request: WorkspaceSymbolRequest) => workspaceSymbol(request)
@@ -69,6 +70,7 @@ class LanguageServer(inStream: InputStream, outStream: OutputStream)(implicit s:
   def formatting(request: TextDocumentFormattingRequest): Task[DocumentFormattingResult] = Task.now(DocumentFormattingResult(Nil))
   def hover(request: TextDocumentHoverRequest): Task[Hover] = Task.now(Hover(Nil, None))
   def references(request: TextDocumentReferencesRequest): Task[ReferencesResult] = Task.now(ReferencesResult(Nil))
+  def rename(request: TextDocumentRenameRequest): Task[RenameResult] = Task.now(RenameResult(WorkspaceEdit(Map.empty)))
   def signatureHelp(request: TextDocumentSignatureHelpRequest): Task[SignatureHelpResult] = Task.now(SignatureHelpResult(Nil, None, None))
 
   // workspace

--- a/languageserver/src/main/scala/langserver/types/types.scala
+++ b/languageserver/src/main/scala/langserver/types/types.scala
@@ -65,6 +65,9 @@ object TextEdit {
 case class WorkspaceEdit(
   changes: Map[String, Seq[TextEdit]] // uri -> changes
   )
+object WorkspaceEdit {
+  implicit val format: OFormat[WorkspaceEdit] = Json.format[WorkspaceEdit]
+}
 
 case class TextDocumentIdentifier(uri: String)
 object TextDocumentIdentifier { implicit val format: OFormat[TextDocumentIdentifier] = Json.format[TextDocumentIdentifier] }

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
@@ -44,6 +44,8 @@ import langserver.messages.TextDocumentReferencesRequest
 import langserver.messages.TextDocumentSignatureHelpRequest
 import langserver.messages.WorkspaceExecuteCommandRequest
 import langserver.messages.ExecuteCommandOptions
+import langserver.messages.RenameResult
+import langserver.messages.TextDocumentRenameRequest
 import langserver.messages.WorkspaceSymbolRequest
 import langserver.messages.WorkspaceSymbolResult
 import langserver.types._
@@ -174,7 +176,8 @@ class ScalametaLanguageServer(
       hoverProvider = true,
       executeCommandProvider =
         ExecuteCommandOptions(WorkspaceCommand.values.map(_.entryName)),
-      workspaceSymbolProvider = true
+      workspaceSymbolProvider = true,
+      renameProvider = true
     )
     InitializeResult(capabilities)
   }
@@ -288,6 +291,11 @@ class ScalametaLanguageServer(
       request.params.context
     )
   }
+
+  override def rename(request: TextDocumentRenameRequest): Task[RenameResult] =
+    Task {
+      RenameProvider.rename(request, symbolIndex, connection)
+    }
 
   override def signatureHelp(
       request: TextDocumentSignatureHelpRequest

--- a/metaserver/src/main/scala/scala/meta/languageserver/Semanticdbs.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Semanticdbs.scala
@@ -6,6 +6,7 @@ import scala.meta.languageserver.compiler.ScalacProvider
 import scala.meta.languageserver.compiler.CompilerEnrichments._
 import scala.meta.parsers.ParseException
 import scala.meta.semanticdb
+import scala.meta.tokenizers.TokenizeException
 import scala.tools.nsc.interactive.Global
 import scala.tools.nsc.reporters.StoreReporter
 import scala.util.control.NonFatal
@@ -38,8 +39,11 @@ object Semanticdbs extends LazyLogging {
       )
     } catch {
       case NonFatal(err) =>
-        if (!err.isInstanceOf[ParseException]) {
-          logger.error(s"Failed to emit semanticdb for ${input.path}", err)
+        err match {
+          case _: ParseException | _: TokenizeException =>
+          // ignore, expected.
+          case _ =>
+            logger.error(s"Failed to emit semanticdb for ${input.path}", err)
         }
         toMessageOnlySemanticdb(input, compiler)
     }

--- a/metaserver/src/main/scala/scala/meta/languageserver/providers/RenameProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/providers/RenameProvider.scala
@@ -1,0 +1,63 @@
+package scala.meta.languageserver.providers
+
+import scala.meta._
+import scala.meta.languageserver.ScalametaEnrichments._
+import scala.meta.languageserver.Uri
+import scala.meta.languageserver.refactoring.Backtick
+import scala.meta.languageserver.search.SymbolIndex
+import com.typesafe.scalalogging.LazyLogging
+import langserver.core.Notifications
+import langserver.messages.RenameResult
+import langserver.messages.TextDocumentRenameRequest
+import langserver.types.MessageType
+import langserver.types.TextEdit
+import langserver.types.WorkspaceEdit
+
+object RenameProvider extends LazyLogging {
+  def rename(
+      request: TextDocumentRenameRequest,
+      symbolIndex: SymbolIndex,
+      notifications: Notifications
+  ): RenameResult = Backtick.backtickWrap(request.params.newName) match {
+    case Left(err) =>
+      // LSP specifies that a ResponseError should be returned in this case
+      // but it seems when we do that at least vscode doesn't display the error
+      // message, only "No result" is displayed to the user, which is not helpful.
+      // I prefer to use showMessage to explain what went wrong and perform
+      // no text edit.
+      notifications.showMessage(MessageType.Warning, err)
+      RenameResult(WorkspaceEdit(Map.empty))
+    case Right(newName) =>
+      val uri = Uri(request.params.textDocument.uri)
+      val edits = for {
+        symbol <- symbolIndex
+          .findSymbol(
+            uri,
+            request.params.position.line,
+            request.params.position.character
+          )
+          .toList
+        if {
+          symbol match {
+            case _: Symbol.Local => true
+            case _ =>
+              notifications.showMessage(
+                MessageType.Warning,
+                s"Rename for global symbol $symbol is not supported yet. " +
+                  s"Only local symbols can be renamed."
+              )
+              false
+          }
+        }
+        data <- symbolIndex.referencesData(symbol)
+        reference <- data.referencePositions(true)
+      } yield {
+        val location = reference.toLocation
+        TextEdit(location.range, newName)
+      }
+      // NOTE(olafur) uri.value is hardcoded here because local symbols
+      // cannot be references across multiple files. When we add support for
+      // renaming global symbols then this needs to change.
+      RenameResult(WorkspaceEdit(Map(uri.value -> edits)))
+  }
+}

--- a/metaserver/src/main/scala/scala/meta/languageserver/refactoring/Backtick.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/refactoring/Backtick.scala
@@ -1,0 +1,72 @@
+// Sources copy-pasted from Ammonite:
+// https://github.com/lihaoyi/Ammonite/blob/73a874173cd337f953a3edc9fb8cb96556638fdd/amm/util/src/main/scala/ammonite/util/Model.scala#L71-L121
+// Original licence: MIT
+// Original author: Li Haoyi
+package scala.meta.languageserver.refactoring
+
+object Backtick {
+  private val alphaKeywords = Set(
+    "abstract", "case", "catch", "class", "def", "do", "else", "extends",
+    "false", "finally", "final", "finally", "forSome", "for", "if", "implicit",
+    "import", "lazy", "match", "new", "null", "object", "override", "package",
+    "private", "protected", "return", "sealed", "super", "this", "throw",
+    "trait", "try", "true", "type", "val", "var", "while", "with", "yield", "_",
+    "macro"
+  )
+  private val symbolKeywords = Set(
+    ":", ";", "=>", "=", "<-", "<:", "<%", ">:", "#", "@", "\u21d2", "\u2190"
+  )
+  // scalafmt: { style = default }
+  private val blockCommentStart = "/*"
+  private val lineCommentStart = "//"
+
+  def needsBacktick(s: String): Boolean = {
+    val chunks = s.split("_", -1)
+    def validOperator(c: Char) = {
+      c.getType == Character.MATH_SYMBOL ||
+      c.getType == Character.OTHER_SYMBOL ||
+      "!#%&*+-/:<=>?@\\^|~".contains(c)
+    }
+    val validChunks = chunks.zipWithIndex.forall {
+      case (chunk, index) =>
+        chunk.forall(c => c.isLetter || c.isDigit || c == '$') ||
+          (chunk.forall(validOperator) &&
+            // operators can only come last
+            index == chunks.length - 1 &&
+            // but cannot be preceded by only a _
+            !(chunks.lift(index - 1).contains("") && index - 1 == 0))
+    }
+
+    val firstLetterValid = s(0).isLetter || s(0) == '_' || s(0) == '$' || validOperator(
+      s(0)
+    )
+
+    val valid =
+      validChunks &&
+        firstLetterValid &&
+        !alphaKeywords.contains(s) &&
+        !symbolKeywords.contains(s) &&
+        !s.contains(blockCommentStart) &&
+        !s.contains(lineCommentStart)
+
+    !valid
+  }
+
+  def backtickWrap(s: String): Either[String, String] = {
+    val ident =
+      if (s.isEmpty) "``"
+      else if (s(0) == '`' && s.last == '`') s
+      else if (s.contains('`')) s
+      else if (needsBacktick(s)) '`' + s + '`'
+      else s
+    import scala.meta._
+    ident.tokenize match {
+      case Tokenized.Success(
+          Tokens(_: Token.BOF, _: Token.Ident, _: Token.EOF)) =>
+        Right(ident)
+      case _ =>
+        Left(s"$s is not a valid identifier")
+    }
+  }
+
+}

--- a/metaserver/src/test/scala/tests/refactoring/BacktickTest.scala
+++ b/metaserver/src/test/scala/tests/refactoring/BacktickTest.scala
@@ -1,0 +1,35 @@
+package tests.refactoring
+
+import scala.meta.languageserver.refactoring.Backtick
+import tests.MegaSuite
+
+object BacktickTest extends MegaSuite {
+
+  def checkOK(identifier: String, expected: String): Unit = {
+    test(s"OK   $identifier") {
+      Backtick.backtickWrap(identifier) match {
+        case Right(obtained) =>
+          assertNoDiff(obtained, expected)
+        case Left(err) => fail(err)
+      }
+    }
+  }
+
+  def checkFail(identifier: String): Unit = {
+    test(s"FAIL $identifier") {
+      Backtick.backtickWrap(identifier) match {
+        case Right(obtained) => fail(s"Expected error, obtained: $obtained")
+        case Left(_) => // OK
+      }
+    }
+  }
+
+  checkFail("`")
+  checkFail("`a ``")
+  checkOK("a b", "`a b`")
+  checkOK("++", "++")
+  checkOK("foo_", "foo_")
+  checkOK("foo_ a", "`foo_ a`")
+  checkOK("a.b", "`a.b`")
+
+}

--- a/test-workspace/src/main/scala/example/User.scala
+++ b/test-workspace/src/main/scala/example/User.scala
@@ -5,4 +5,8 @@ case class User(name: String, age: Int)
 object a {
   val x = "ba"
   val y = List(1, x).length
+  def z = {
+    val localSymbol = "222" // can be renamed
+    localSymbol.length
+  }
 }


### PR DESCRIPTION

This commit implements renaming for local symbols. An error message is
presented to the user in case the symbol is global or the new name is
not a valid identifier.

Fixes first part of https://github.com/scalameta/language-server/issues/149

![2017-12-22 15 32 18](https://user-images.githubusercontent.com/1408093/34301554-66aadd36-e72d-11e7-8c1d-d6417819c4ee.gif)

![2017-12-22 15 37 50](https://user-images.githubusercontent.com/1408093/34301746-2057b218-e72e-11e7-99c5-a48e8b4eec69.gif)