### PR TITLE
Implement textEdit/codeAction

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -143,6 +143,7 @@ lazy val testWorkspace = project
       // Need to fix source root so it matches the workspace folder.
       s"-P:semanticdb:sourceroot:${baseDirectory.value}"
     },
+    scalacOptions += "-Ywarn-unused-import",
     scalacOptions -= "-Xlint"
   )
   .disablePlugins(ScalafixPlugin)

--- a/languageserver/src/main/scala/langserver/core/Connection.scala
+++ b/languageserver/src/main/scala/langserver/core/Connection.scala
@@ -59,7 +59,7 @@ abstract class Connection(inStream: InputStream, outStream: OutputStream)(implic
     }
   }
 
-  var i = new AtomicInteger()
+  private val i = new AtomicInteger()
   // send request for workspace/applyEdit ignoring response
   def workspaceApplyEdit(params: ApplyWorkspaceEditParams): Unit = {
     val json = JsonRpcRequestMessage("workspace/applyEdit", Json.toJsObject(params), NumericCorrelationId(i.getAndIncrement()))

--- a/languageserver/src/main/scala/langserver/core/Connection.scala
+++ b/languageserver/src/main/scala/langserver/core/Connection.scala
@@ -4,6 +4,7 @@ import java.util.{Map => JMap}
 import java.io.InputStream
 import java.io.OutputStream
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.Future
 import scala.util.Failure
@@ -56,6 +57,13 @@ abstract class Connection(inStream: InputStream, outStream: OutputStream)(implic
       future.cancel()
       activeRequestsById.remove(id)
     }
+  }
+
+  var i = new AtomicInteger()
+  // send request for workspace/applyEdit ignoring response
+  def workspaceApplyEdit(params: ApplyWorkspaceEditParams): Unit = {
+    val json = JsonRpcRequestMessage("workspace/applyEdit", Json.toJsObject(params), NumericCorrelationId(i.getAndIncrement()))
+    msgWriter.write(json)
   }
 
   def sendNotification(params: Notification): Unit = {
@@ -119,7 +127,8 @@ abstract class Connection(inStream: InputStream, outStream: OutputStream)(implic
                 }
 
               case response: JsonRpcResponseMessage =>
-                // logger.debug(s"Received response: $response")
+                // TODO(olafur) complete request, for example workspace/applyEdit
+                logger.debug(s"Received response: $response")
 
               case m =>
                 logger.error(s"Received unknown message: $m")

--- a/languageserver/src/main/scala/langserver/core/LanguageServer.scala
+++ b/languageserver/src/main/scala/langserver/core/LanguageServer.scala
@@ -17,6 +17,7 @@ class LanguageServer(inStream: InputStream, outStream: OutputStream)(implicit s:
     override def commandHandler(method: String, command: ServerCommand): Task[ResultResponse] = (method, command) match {
       case ("initialize", request: InitializeParams) => initialize(request)
       case ("textDocument/completion", request: TextDocumentCompletionRequest) => completion(request)
+      case ("textDocument/codeAction", request: CodeActionRequest) => codeAction(request)
       case ("textDocument/definition", request: TextDocumentDefinitionRequest) => definition(request)
       case ("textDocument/documentHighlight", request: TextDocumentDocumentHighlightRequest) => documentHighlight(request)
       case ("textDocument/documentSymbol", request: DocumentSymbolParams) => documentSymbol(request)
@@ -66,6 +67,7 @@ class LanguageServer(inStream: InputStream, outStream: OutputStream)(implicit s:
 
   // textDocument
   def completion(request: TextDocumentCompletionRequest): Task[CompletionList] = Task.now(CompletionList(isIncomplete = false, Nil))
+  def codeAction(request: CodeActionRequest): Task[CodeActionResult] = Task.now(CodeActionResult(Nil))
   def definition(request: TextDocumentDefinitionRequest): Task[DefinitionResult] = Task.now(DefinitionResult(Nil))
   def documentHighlight(request: TextDocumentDocumentHighlightRequest): Task[DocumentHighlightResult] = Task.now(DocumentHighlightResult(Nil))
   def documentSymbol(request: DocumentSymbolParams): Task[DocumentSymbolResult] = Task.now(DocumentSymbolResult(Nil))

--- a/languageserver/src/main/scala/langserver/messages/Commands.scala
+++ b/languageserver/src/main/scala/langserver/messages/Commands.scala
@@ -200,6 +200,19 @@ object RenameParams {
   implicit val format: OFormat[RenameParams] = Json.format[RenameParams]
 }
 
+case class CodeActionParams(
+  textDocument: TextDocumentIdentifier,
+  range: Range,
+  context: CodeActionContext
+)
+object CodeActionParams {
+  implicit val format: OFormat[CodeActionParams] = Json.format[CodeActionParams]
+}
+
+case class CodeActionRequest(params: CodeActionParams) extends ServerCommand
+object CodeActionRequest {
+  implicit val format: OFormat[CodeActionRequest] = Json.format[CodeActionRequest]
+}
 case class DocumentSymbolParams(textDocument: TextDocumentIdentifier) extends ServerCommand
 case class TextDocumentRenameRequest(params: RenameParams) extends ServerCommand
 object TextDocumentRenameRequest {
@@ -229,6 +242,7 @@ object ServerCommand extends CommandCompanion[ServerCommand] {
   override val CommandFormats = Message.MessageFormats(
     "initialize" -> Json.format[InitializeParams],
     "textDocument/completion" -> valueFormat(TextDocumentCompletionRequest)(_.params),
+    "textDocument/codeAction" -> valueFormat(TextDocumentCompletionRequest)(_.params),
     "textDocument/rename" -> valueFormat(TextDocumentRenameRequest.apply)(_.params),
     "textDocument/signatureHelp" -> valueFormat(TextDocumentSignatureHelpRequest)(_.params),
     "textDocument/definition" -> valueFormat(TextDocumentDefinitionRequest)(_.params),
@@ -318,6 +332,10 @@ case class RenameResult(params: WorkspaceEdit) extends ResultResponse
 object RenameResult {
   implicit val format: OFormat[RenameResult] = Json.format[RenameResult]
 }
+case class CodeActionResult(params: Seq[Command]) extends ResultResponse
+object CodeActionResult {
+  implicit val format: OFormat[CodeActionResult] = Json.format[CodeActionResult]
+}
 case class DocumentSymbolResult(params: Seq[SymbolInformation]) extends ResultResponse
 case class DefinitionResult(params: Seq[Location]) extends ResultResponse
 case class ReferencesResult(params: Seq[Location]) extends ResultResponse
@@ -341,6 +359,7 @@ object ResultResponse extends ResponseCompanion[Any] {
   override val ResponseFormats = Message.MessageFormats(
     "initialize" -> Json.format[InitializeResult],
     "textDocument/completion" -> Json.format[CompletionList],
+    "textDocument/codeAction" -> valueFormat(CodeActionResult.apply)(_.params),
     "textDocument/rename" -> valueFormat(RenameResult.apply)(_.params),
     "textDocument/signatureHelp" -> Json.format[SignatureHelpResult],
     "textDocument/definition" -> valueFormat(DefinitionResult)(_.params),

--- a/languageserver/src/main/scala/langserver/messages/Commands.scala
+++ b/languageserver/src/main/scala/langserver/messages/Commands.scala
@@ -227,6 +227,10 @@ case class TextDocumentHoverRequest(params: TextDocumentPositionParams) extends 
 case class TextDocumentFormattingRequest(params: DocumentFormattingParams) extends ServerCommand
 case class WorkspaceExecuteCommandRequest(params: WorkspaceExecuteCommandParams) extends ServerCommand
 case class WorkspaceSymbolRequest(params: WorkspaceSymbolParams) extends ServerCommand
+case class ApplyWorkspaceEditParams(label: Option[String], edit: WorkspaceEdit)
+object ApplyWorkspaceEditParams {
+  implicit val format: OFormat[ApplyWorkspaceEditParams] = Json.format[ApplyWorkspaceEditParams]
+}
 
 case class Hover(contents: Seq[MarkedString], range: Option[Range]) extends ResultResponse
 object Hover {
@@ -242,7 +246,7 @@ object ServerCommand extends CommandCompanion[ServerCommand] {
   override val CommandFormats = Message.MessageFormats(
     "initialize" -> Json.format[InitializeParams],
     "textDocument/completion" -> valueFormat(TextDocumentCompletionRequest)(_.params),
-    "textDocument/codeAction" -> valueFormat(TextDocumentCompletionRequest)(_.params),
+    "textDocument/codeAction" -> valueFormat(CodeActionRequest.apply)(_.params),
     "textDocument/rename" -> valueFormat(TextDocumentRenameRequest.apply)(_.params),
     "textDocument/signatureHelp" -> valueFormat(TextDocumentSignatureHelpRequest)(_.params),
     "textDocument/definition" -> valueFormat(TextDocumentDefinitionRequest)(_.params),

--- a/languageserver/src/main/scala/langserver/types/types.scala
+++ b/languageserver/src/main/scala/langserver/types/types.scala
@@ -67,7 +67,7 @@ object TextEdit {
  */
 case class WorkspaceEdit(
   changes: Map[String, Seq[TextEdit]] // uri -> changes
-  )
+)
 object WorkspaceEdit {
   implicit val format: OFormat[WorkspaceEdit] = Json.format[WorkspaceEdit]
 }

--- a/languageserver/src/main/scala/langserver/types/types.scala
+++ b/languageserver/src/main/scala/langserver/types/types.scala
@@ -50,7 +50,10 @@ object Diagnostic {
  * @param command The identifier of the actual command handler
  * @param arguments The arugments this command may be invoked with
  */
-case class Command(title: String, command: String, arguments: Seq[Any])
+case class Command(title: String, command: String, arguments: Seq[JsValue])
+object Command {
+  implicit val format: OFormat[Command] = Json.format[Command]
+}
 
 case class TextEdit(range: Range, newText: String)
 
@@ -184,6 +187,9 @@ object WorkspaceSymbolParams {
 }
 
 case class CodeActionContext(diagnostics: Seq[Diagnostic])
+object CodeActionContext {
+  implicit val format: OFormat[CodeActionContext] = Json.format[CodeActionContext]
+}
 
 /**
  * A code lens represents a [command](#Command) that should be shown along with

--- a/metaserver/src/main/scala/scala/meta/languageserver/Main.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Main.scala
@@ -5,6 +5,7 @@ import java.io.PrintStream
 import java.nio.file.Files
 import java.util.concurrent.Executors
 import scala.util.Properties
+import scala.util.control.NonFatal
 import com.typesafe.scalalogging.LazyLogging
 import monix.execution.Scheduler
 import monix.execution.schedulers.SchedulerService
@@ -32,6 +33,9 @@ object Main extends LazyLogging {
       val server = new ScalametaLanguageServer(config, stdin, stdout, out)
       LSPLogger.connection = Some(server.connection)
       server.start()
+    } catch {
+      case NonFatal(e) =>
+        logger.error("Uncaught top-level exception", e)
     } finally {
       System.setOut(stdout)
       System.setErr(stderr)

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaEnrichments.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaEnrichments.scala
@@ -101,7 +101,10 @@ object ScalametaEnrichments {
     }
   }
   implicit class XtensionInputLSP(val input: m.Input) extends AnyVal {
-    def contents: String = input.asInstanceOf[m.Input.VirtualFile].value
+    def contents: String = input match {
+      case m.Input.VirtualFile(_, value) => value
+      case _ => new String(input.chars)
+    }
   }
   implicit class XtensionIndexPosition(val pos: i.Position) extends AnyVal {
     def pretty: String =

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaEnrichments.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaEnrichments.scala
@@ -5,6 +5,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Paths
 import scala.meta.languageserver.{index => i}
+import org.langmeta.internal.semanticdb.{schema => s}
 import scala.{meta => m}
 import langserver.types.SymbolKind
 import langserver.{types => l}
@@ -305,5 +306,12 @@ object ScalametaEnrichments {
         .filterNot { _.uri.startsWith("jar:file") } // definition may refer to a jar
     }
 
+  }
+  implicit class XtensionSchemaDocument(val document: s.Document)
+      extends AnyVal {
+
+    /** Returns scala.meta.Document from protobuf schema.Document */
+    def toMetaDocument: m.Document =
+      s.Database(document :: Nil).toDb(None).documents.head
   }
 }

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
@@ -21,6 +21,8 @@ import org.langmeta.languageserver.InputEnrichments._
 import com.typesafe.scalalogging.LazyLogging
 import io.github.soc.directories.ProjectDirectories
 import langserver.core.LanguageServer
+import langserver.messages.CodeActionRequest
+import langserver.messages.CodeActionResult
 import langserver.messages.CompletionList
 import langserver.messages.CompletionOptions
 import langserver.messages.DefinitionResult
@@ -189,7 +191,8 @@ class ScalametaLanguageServer(
       executeCommandProvider =
         ExecuteCommandOptions(WorkspaceCommand.values.map(_.entryName)),
       workspaceSymbolProvider = true,
-      renameProvider = true
+      renameProvider = true,
+      codeActionProvider = true
     )
     InitializeResult(capabilities)
   }
@@ -250,6 +253,11 @@ class ScalametaLanguageServer(
       case None => CompletionProvider.empty
     }
   }
+
+  override def codeAction(request: CodeActionRequest): Task[CodeActionResult] =
+    Task {
+      CodeActionProvider.codeActions(request)
+    }
 
   override def definition(
       request: TextDocumentDefinitionRequest

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
@@ -1,14 +1,14 @@
 package scala.meta.languageserver
 
 import java.io.File
+import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
 import java.io.PrintStream
-import java.io.IOException
+import java.nio.file.FileVisitResult
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.SimpleFileVisitor
-import java.nio.file.FileVisitResult
 import java.nio.file.attribute.BasicFileAttributes
 import java.util.concurrent.Executors
 import scala.concurrent.duration.FiniteDuration
@@ -16,8 +16,8 @@ import scala.meta.languageserver.compiler.CompilerConfig
 import scala.meta.languageserver.compiler.Cursor
 import scala.meta.languageserver.compiler.ScalacProvider
 import scala.meta.languageserver.providers._
+import scala.meta.languageserver.refactoring.OrganizeImports
 import scala.meta.languageserver.search.SymbolIndex
-import org.langmeta.languageserver.InputEnrichments._
 import com.typesafe.scalalogging.LazyLogging
 import io.github.soc.directories.ProjectDirectories
 import langserver.core.LanguageServer
@@ -30,10 +30,12 @@ import langserver.messages.DocumentFormattingResult
 import langserver.messages.DocumentHighlightResult
 import langserver.messages.DocumentSymbolParams
 import langserver.messages.DocumentSymbolResult
+import langserver.messages.ExecuteCommandOptions
 import langserver.messages.Hover
 import langserver.messages.InitializeParams
 import langserver.messages.InitializeResult
 import langserver.messages.ReferencesResult
+import langserver.messages.RenameResult
 import langserver.messages.ServerCapabilities
 import langserver.messages.ShutdownResult
 import langserver.messages.SignatureHelpOptions
@@ -44,11 +46,9 @@ import langserver.messages.TextDocumentDocumentHighlightRequest
 import langserver.messages.TextDocumentFormattingRequest
 import langserver.messages.TextDocumentHoverRequest
 import langserver.messages.TextDocumentReferencesRequest
+import langserver.messages.TextDocumentRenameRequest
 import langserver.messages.TextDocumentSignatureHelpRequest
 import langserver.messages.WorkspaceExecuteCommandRequest
-import langserver.messages.ExecuteCommandOptions
-import langserver.messages.RenameResult
-import langserver.messages.TextDocumentRenameRequest
 import langserver.messages.WorkspaceSymbolRequest
 import langserver.messages.WorkspaceSymbolResult
 import langserver.types._
@@ -65,6 +65,7 @@ import org.langmeta.internal.io.PathIO
 import org.langmeta.internal.semanticdb.XtensionDatabase
 import org.langmeta.internal.semanticdb.schema
 import org.langmeta.io.AbsolutePath
+import org.langmeta.languageserver.InputEnrichments._
 import org.langmeta.semanticdb
 import play.api.libs.json.JsValue
 import play.api.libs.json.JsSuccess
@@ -343,7 +344,9 @@ class ScalametaLanguageServer(
     sourceChangeSubscriber.onNext(input)
   }
 
-  override def executeCommand(request: WorkspaceExecuteCommandRequest) = Task {
+  override def executeCommand(
+      request: WorkspaceExecuteCommandRequest
+  ): Task[Unit] = Task {
     import WorkspaceCommand._
     WorkspaceCommand
       .withNameOption(request.params.command)
@@ -358,6 +361,11 @@ class ScalametaLanguageServer(
         case ResetPresentationCompiler =>
           logger.info("Resetting all compiler instances")
           scalac.resetCompilers()
+        case ScalafixUnusedImports =>
+          logger.info("Removing unused imports")
+          val result =
+            OrganizeImports.removeUnused(request.params.arguments, symbolIndex)
+          connection.workspaceApplyEdit(result)
       }
   }
 

--- a/metaserver/src/main/scala/scala/meta/languageserver/WorkspaceCommand.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/WorkspaceCommand.scala
@@ -10,6 +10,7 @@ case object WorkspaceCommand extends Enum[WorkspaceCommand] {
 
   case object ClearIndexCache extends WorkspaceCommand
   case object ResetPresentationCompiler extends WorkspaceCommand
+  case object ScalafixUnusedImports extends WorkspaceCommand
 
   val values = findValues
 

--- a/metaserver/src/main/scala/scala/meta/languageserver/providers/CodeActionProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/providers/CodeActionProvider.scala
@@ -1,0 +1,13 @@
+package scala.meta.languageserver.providers
+
+import com.typesafe.scalalogging.LazyLogging
+import langserver.messages.CodeActionRequest
+import langserver.messages.CodeActionResult
+import play.api.libs.json.Json
+
+object CodeActionProvider extends LazyLogging {
+  def codeActions(request: CodeActionRequest): CodeActionResult = {
+    logger.info(Json.prettyPrint(Json.toJson(request)))
+    CodeActionResult(Nil)
+  }
+}

--- a/metaserver/src/main/scala/scala/meta/languageserver/providers/CodeActionProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/providers/CodeActionProvider.scala
@@ -1,13 +1,23 @@
 package scala.meta.languageserver.providers
 
+import scala.meta.languageserver.WorkspaceCommand.ScalafixUnusedImports
 import com.typesafe.scalalogging.LazyLogging
 import langserver.messages.CodeActionRequest
 import langserver.messages.CodeActionResult
+import langserver.types.Command
+import langserver.types.Diagnostic
 import play.api.libs.json.Json
 
 object CodeActionProvider extends LazyLogging {
   def codeActions(request: CodeActionRequest): CodeActionResult = {
-    logger.info(Json.prettyPrint(Json.toJson(request)))
-    CodeActionResult(Nil)
+    val removeUnusedImports = request.params.context.diagnostics.collectFirst {
+      case Diagnostic(_, _, _, Some("scalac"), "Unused import") =>
+        Command(
+          "Remove unused imports",
+          ScalafixUnusedImports.entryName,
+          Json.toJson(request.params.textDocument) :: Nil
+        )
+    }.toList
+    CodeActionResult(removeUnusedImports)
   }
 }

--- a/metaserver/src/main/scala/scala/meta/languageserver/refactoring/OrganizeImports.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/refactoring/OrganizeImports.scala
@@ -1,0 +1,65 @@
+package scala.meta.languageserver.refactoring
+
+import scala.meta._
+import org.langmeta.internal.semanticdb._
+import org.langmeta.internal.semanticdb.schema
+import scala.meta.languageserver.Parser
+import scala.meta.languageserver.Uri
+import scala.meta.languageserver.search.SymbolIndex
+import scalafix.internal.rule.RemoveUnusedImports
+import scalafix.languageserver.ScalafixEnrichments._
+import scalafix.languageserver.ScalafixPatchEnrichments._
+import scalafix.rule.RuleCtx
+import scalafix.util.SemanticdbIndex
+import com.typesafe.scalalogging.LazyLogging
+import langserver.messages.ApplyWorkspaceEditParams
+import langserver.messages.InvalidParamsResponseError
+import langserver.types.TextDocumentIdentifier
+import langserver.types.WorkspaceEdit
+import play.api.libs.json.JsValue
+import play.api.libs.json.Json
+
+object OrganizeImports extends LazyLogging {
+
+  val empty = ApplyWorkspaceEditParams(None, WorkspaceEdit(Map.empty))
+
+  def removeUnused(
+      arguments: Option[Seq[JsValue]],
+      index: SymbolIndex
+  ): ApplyWorkspaceEditParams = {
+    val result = for {
+      as <- arguments
+      argument <- as.headOption
+      textDocument <- Json.fromJson[TextDocumentIdentifier](argument).asOpt
+    } yield removeUnused(Uri(textDocument), index)
+    result.getOrElse(
+      throw InvalidParamsResponseError(
+        s"Unable to parse TextDocumentIdentifier from $arguments"
+      )
+    )
+  }
+
+  def removeUnused(uri: Uri, index: SymbolIndex): ApplyWorkspaceEditParams = {
+    index.documentIndex.getDocument(uri) match {
+      case Some(document) =>
+        removeUnused(
+          uri,
+          schema.Database(document :: Nil).toDb(None).documents.head
+        )
+      case None => empty
+    }
+  }
+
+  def removeUnused(uri: Uri, document: Document): ApplyWorkspaceEditParams = {
+    val index = SemanticdbIndex.load(document)
+    val rule = RemoveUnusedImports(index)
+    val tree = Parser.parse(document.input).get
+    val ctx = RuleCtx(tree)
+    val patch = rule.fixWithNameInternal(ctx).values.asPatch
+    val edits = patch.toTextEdits(ctx, index)
+    ApplyWorkspaceEditParams(
+      label = Some(s"Remove unused imports"),
+      edit = WorkspaceEdit(Map(uri.value -> edits))
+    )
+  }
+}

--- a/metaserver/src/main/scala/scala/meta/languageserver/refactoring/OrganizeImports.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/refactoring/OrganizeImports.scala
@@ -1,12 +1,11 @@
 package scala.meta.languageserver.refactoring
 
 import scala.meta._
-import org.langmeta.internal.semanticdb._
-import org.langmeta.internal.semanticdb.schema
 import scala.meta.languageserver.Parser
 import scala.meta.languageserver.Uri
 import scala.meta.languageserver.search.SymbolIndex
 import scalafix.internal.rule.RemoveUnusedImports
+import scala.meta.languageserver.ScalametaEnrichments._
 import scalafix.languageserver.ScalafixEnrichments._
 import scalafix.languageserver.ScalafixPatchEnrichments._
 import scalafix.rule.RuleCtx
@@ -42,10 +41,7 @@ object OrganizeImports extends LazyLogging {
   def removeUnused(uri: Uri, index: SymbolIndex): ApplyWorkspaceEditParams = {
     index.documentIndex.getDocument(uri) match {
       case Some(document) =>
-        removeUnused(
-          uri,
-          schema.Database(document :: Nil).toDb(None).documents.head
-        )
+        removeUnused(uri, document.toMetaDocument)
       case None => empty
     }
   }

--- a/metaserver/src/main/scala/scala/meta/languageserver/refactoring/TextEdits.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/refactoring/TextEdits.scala
@@ -1,0 +1,41 @@
+package scala.meta.languageserver.refactoring
+
+import scala.meta.Input
+import org.langmeta.languageserver.InputEnrichments._
+import scala.annotation.tailrec
+import langserver.types.TextEdit
+import scala.meta.languageserver.ScalametaEnrichments._
+
+/** Re-implementation of how TextEdits should be handled by the editor client
+ *
+ * Useful for testing/logging purposes. Instead of reading massive JSON blobs like
+ * [{"range":{"start":{"line":1,"character":0},"end":{"line":2,"character":0}},"newText":""},
+ *  ...]
+ * you can look at how the code looks like applied instead.
+ */
+object TextEdits {
+  def applyToInput(
+      input: Input,
+      edits: List[TextEdit]
+  ): String = {
+    val original = input.contents
+    val sb = new java.lang.StringBuilder
+    @tailrec def loop(i: Int, es: List[TextEdit]): Unit = {
+      val isDone = i >= original.length
+      if (isDone) ()
+      else {
+        es match {
+          case Nil =>
+            sb.append(original.substring(i))
+          case edit :: tail =>
+            val pos = input.toPosition(edit.range)
+            sb.append(original.substring(i, pos.start))
+              .append(edit.newText)
+            loop(pos.end, tail)
+        }
+      }
+    }
+    loop(0, edits)
+    sb.toString
+  }
+}

--- a/metaserver/src/main/scala/scalafix/languageserver/ScalafixEnrichments.scala
+++ b/metaserver/src/main/scala/scalafix/languageserver/ScalafixEnrichments.scala
@@ -1,15 +1,18 @@
 package scalafix.languageserver
 
 import scala.meta.Tree
+import scala.meta.languageserver.ScalametaEnrichments._
+import scala.{meta => m}
 import scalafix.Rule
+import scalafix.SemanticdbIndex
 import scalafix.internal.config.ScalafixConfig
+import scalafix.internal.util.EagerInMemorySemanticdbIndex
 import scalafix.lint.LintMessage
+import scalafix.lint.LintSeverity
 import scalafix.patch.Patch
 import scalafix.rule.RuleCtx
 import scalafix.rule.RuleName
 import langserver.{types => l}
-import scala.meta.languageserver.ScalametaEnrichments._
-import scalafix.lint.LintSeverity
 
 object ScalafixEnrichments {
   implicit class XtensionLintMessageLSP(val msg: LintMessage) extends AnyVal {
@@ -34,7 +37,7 @@ object ScalafixEnrichments {
     def applyInternal(tree: Tree, config: ScalafixConfig): RuleCtx =
       RuleCtx(tree, config)
   }
-  implicit class XtensionPatchLSP(val `_`: Patch.type) extends AnyVal {
+  implicit class XtensionPatchLSPObject(val `_`: Patch.type) extends AnyVal {
     def lintMessagesInternal(
         patches: Map[RuleName, Patch],
         ctx: RuleCtx
@@ -44,5 +47,14 @@ object ScalafixEnrichments {
   implicit class XtensionRuleLSP(val rule: Rule) extends AnyVal {
     def fixWithNameInternal(ctx: RuleCtx): Map[RuleName, Patch] =
       rule.fixWithName(ctx)
+  }
+  implicit class XtensionSemanticdbIndexObject(val `_`: SemanticdbIndex.type)
+      extends AnyVal {
+    def load(document: m.Document): SemanticdbIndex =
+      EagerInMemorySemanticdbIndex(
+        m.Database(document :: Nil),
+        m.Sourcepath(Nil),
+        m.Classpath(Nil)
+      )
   }
 }

--- a/metaserver/src/main/scala/scalafix/languageserver/ScalafixPatchEnrichments.scala
+++ b/metaserver/src/main/scala/scalafix/languageserver/ScalafixPatchEnrichments.scala
@@ -1,0 +1,117 @@
+package scalafix.languageserver
+
+import scala.collection.immutable.Seq
+import scala.meta.languageserver.ScalametaEnrichments._
+import scalafix.SemanticdbIndex
+import scalafix.internal.patch.ImportPatchOps
+import scalafix.internal.patch.ReplaceSymbolOps
+import scalafix.internal.util.Failure
+import scalafix.internal.util.TokenOps
+import scalafix.patch.Concat
+import scalafix.patch.EmptyPatch
+import scalafix.patch.LintPatch
+import scalafix.patch.Patch
+import scalafix.patch.TokenPatch
+import scalafix.patch.TreePatch.ImportPatch
+import scalafix.patch.TreePatch.ReplaceSymbol
+import scalafix.rule.RuleCtx
+import langserver.types.TextEdit
+
+// Copy-pasta from scalafix because all of these methods are private.
+// We should expose a package private API to get a list of token patches from
+// a Patch.
+// TODO(olafur): Figure out how to expose a minimal public API in scalafix.Patch
+// that supports this use-case.
+// All of the copy-paste below could be avoided with a single:
+//   Patch.toTokenPatches(Patch): Iterable[TokenPatch]
+object ScalafixPatchEnrichments {
+
+  implicit class XtensionPatchLSP(val patch: Patch) extends AnyVal {
+
+    /** Converts a scalafix.Patch to precise languageserver.types.TextEdit.
+     *
+     * We could take a shortcut and apply the patch to a String and return one
+     * large TextEdit that replaces the whole file. However, in scalafix
+     * we treat each token individually so we can provide more precise changes.
+     */
+    def toTextEdits(
+        implicit ctx: RuleCtx,
+        index: SemanticdbIndex
+    ): List[TextEdit] = {
+      val mergedTokenPatches = tokenPatches(patch)
+        .groupBy(x => TokenOps.hash(x.tok))
+        .values
+        .map(_.reduce(merge))
+      mergedTokenPatches.toArray
+        .sortBy(_.tok.pos.start)
+        .iterator
+        .map { tokenPatch =>
+          TextEdit(tokenPatch.tok.pos.toRange, tokenPatch.newTok)
+        }
+        .toList
+    }
+  }
+  private def tokenPatches(
+      patch: Patch
+  )(implicit ctx: RuleCtx, index: SemanticdbIndex): Iterable[TokenPatch] = {
+    val base = underlying(patch)
+    val moveSymbol = underlying(
+      ReplaceSymbolOps.naiveMoveSymbolPatch(base.collect {
+        case m: ReplaceSymbol => m
+      })
+    )
+    val patches = base.filterNot(_.isInstanceOf[ReplaceSymbol]) ++ moveSymbol
+    val tokenPatches = patches.collect { case e: TokenPatch => e }
+    val importPatches = patches.collect { case e: ImportPatch => e }
+    val importTokenPatches = {
+      val result = ImportPatchOps.superNaiveImportPatchToTokenPatchConverter(
+        ctx,
+        importPatches
+      )
+      underlying(result.asPatch)
+        .collect {
+          case x: TokenPatch => x
+          case els =>
+            throw Failure.InvariantFailedException(
+              s"Expected TokenPatch, got $els"
+            )
+        }
+    }
+    importTokenPatches ++ tokenPatches
+  }
+  private def underlying(patch: Patch): Seq[Patch] = {
+    val builder = Seq.newBuilder[Patch]
+    foreach(patch) {
+      case _: LintPatch =>
+      case els =>
+        builder += els
+    }
+    builder.result()
+  }
+  private def foreach(patch: Patch)(f: Patch => Unit): Unit = {
+    def loop(patch: Patch): Unit = patch match {
+      case Concat(a, b) =>
+        loop(a)
+        loop(b)
+      case EmptyPatch => // do nothing
+      case els =>
+        f(els)
+    }
+    loop(patch)
+  }
+
+  import scalafix.patch.TokenPatch._
+  private def merge(a: TokenPatch, b: TokenPatch): TokenPatch = (a, b) match {
+    case (add1: Add, add2: Add) =>
+      Add(
+        add1.tok,
+        add1.addLeft + add2.addLeft,
+        add1.addRight + add2.addRight,
+        add1.keepTok && add2.keepTok
+      )
+    case (_: Remove, add: Add) => add.copy(keepTok = false)
+    case (add: Add, _: Remove) => add.copy(keepTok = false)
+    case (rem: Remove, rem2: Remove) => rem
+    case _ => throw Failure.TokenPatchMergeError(a, b)
+  }
+}

--- a/metaserver/src/test/scala/tests/compiler/CompilerSuite.scala
+++ b/metaserver/src/test/scala/tests/compiler/CompilerSuite.scala
@@ -1,9 +1,11 @@
 package tests.compiler
 
+import scala.meta.interactive.InteractiveSemanticdb
 import scala.meta.languageserver.Uri
 import scala.meta.languageserver.compiler.Cursor
 import scala.meta.languageserver.compiler.ScalacProvider
 import scala.tools.nsc.interactive.Global
+import org.langmeta.semanticdb.Document
 import tests.MegaSuite
 
 class CompilerSuite extends MegaSuite {
@@ -13,6 +15,10 @@ class CompilerSuite extends MegaSuite {
       "-Ywarn-unused-import" ::
       Nil
   )
+
+  def toDocument(name: String, code: String): Document = {
+    InteractiveSemanticdb.toDocument(compiler, code, name, 10000)
+  }
 
   private def computeChevronPositionFromMarkup(
       filename: String,

--- a/metaserver/src/test/scala/tests/refactoring/RemoveUnusedImportsTest.scala
+++ b/metaserver/src/test/scala/tests/refactoring/RemoveUnusedImportsTest.scala
@@ -1,0 +1,57 @@
+package tests.refactoring
+
+import scala.meta.languageserver.Uri
+import scala.meta.languageserver.refactoring.OrganizeImports
+import scala.meta.languageserver.refactoring.TextEdits
+import org.langmeta.inputs.Input
+import tests.compiler.CompilerSuite
+
+// This test suite is not supposed to test the actual scalafix implementation,
+// it is only supposed to check that the conversion from scalafix.Patch to
+// languageserver.TextEdit is accurate.
+object RemoveUnusedImportsTest extends CompilerSuite {
+  def check(name: String, original: String, expectedEdits: String): Unit = {
+    test(name) {
+      val uri = Uri.file(name)
+      val document = toDocument(uri.value, original)
+      val edits = OrganizeImports
+        .removeUnused(uri, document)
+        .edit
+        .changes(uri.value)
+        .toList
+      val obtained =
+        TextEdits.applyToInput(Input.VirtualFile(name, original), edits)
+      assertNoDiff(obtained, expectedEdits)
+    }
+  }
+
+  check(
+    "remove-all",
+    """
+      |import scala.concurrent.{Future, Await}
+      |import scala.math.max
+    """.stripMargin,
+    ""
+  )
+
+  check(
+    "grouped",
+    """
+      |import scala.concurrent.{Future, Await}
+      |import scala.math.max
+      |object a {
+      |  max(1, 2)
+      |  Future.successful(1)
+      |}
+    """.stripMargin,
+    """
+      |import scala.concurrent.Future
+      |import scala.math.max
+      |object a {
+      |  max(1, 2)
+      |  Future.successful(1)
+      |}
+    """.stripMargin
+  )
+
+}


### PR DESCRIPTION
This PR implements a codeAction to remove unused imports with scalafix. The patch produced by scalafix is converted to precise `TextEdit` per changed token, instead of sending a single TextEdit to replace the whole file as we do with scalafmt.

![2017-12-22 22 33 45](https://user-images.githubusercontent.com/1408093/34313973-b471090e-e76f-11e7-9e2b-09f4716cf153.gif)

codeActions appear as lightbulbs above the cursor and when the lightbulb is clicked a dialogue opens with a list of commands to run (not shown in gif).

All of `ScalafixPatchEnrichments` is copy pasted from the scalafix sources, with the next release of scalafix this file will no longer be necessary since in master we have an API to get `List[TokenPatch]` from a `Patch`
