### PR TITLE
Add support for configuration

### DIFF
--- a/languageserver/src/main/scala/langserver/core/LanguageServer.scala
+++ b/languageserver/src/main/scala/langserver/core/LanguageServer.scala
@@ -7,6 +7,7 @@ import langserver.messages._
 import langserver.types._
 import monix.eval.Task
 import monix.execution.Scheduler
+import play.api.libs.json.JsValue
 
 /**
  * A language server implementation. Users should subclass this class and implement specific behavior.
@@ -38,7 +39,8 @@ class LanguageServer(inStream: InputStream, outStream: OutputStream)(implicit s:
     case DidChangeTextDocumentParams(td, changes) => onChangeTextDocument(td, changes)
     case DidSaveTextDocumentParams(td) => onSaveTextDocument(td)
     case DidCloseTextDocumentParams(td) => onCloseTextDocument(td)
-    case DidChangeWatchedFiles(changes) => onChangeWatchedFiles(changes)
+    case DidChangeWatchedFilesParams(changes) => onChangeWatchedFiles(changes)
+    case DidChangeConfigurationParams(settings) => onChangeConfiguration(settings)
     case e => logger.error(s"Unknown notification $e")
   }
 
@@ -95,5 +97,8 @@ class LanguageServer(inStream: InputStream, outStream: OutputStream)(implicit s:
 
   def onChangeWatchedFiles(changes: Seq[FileEvent]): Unit =
     logger.debug(s"changeWatchedFiles $changes")
+
+  def onChangeConfiguration(settings: JsValue): Unit =
+    logger.debug(s"changeConfiguration $settings")
 
 }

--- a/languageserver/src/main/scala/langserver/messages/Commands.scala
+++ b/languageserver/src/main/scala/langserver/messages/Commands.scala
@@ -277,7 +277,8 @@ case class DidChangeTextDocumentParams(
 
 case class DidCloseTextDocumentParams(textDocument: TextDocumentIdentifier) extends Notification
 case class DidSaveTextDocumentParams(textDocument: TextDocumentIdentifier) extends Notification
-case class DidChangeWatchedFiles(changes: Seq[FileEvent]) extends Notification
+case class DidChangeWatchedFilesParams(changes: Seq[FileEvent]) extends Notification
+case class DidChangeConfigurationParams(settings: JsValue) extends Notification
 
 case class Initialized() extends Notification
 object Initialized {
@@ -298,7 +299,8 @@ object Notification extends NotificationCompanion[Notification] {
     "textDocument/didChange" -> Json.format[DidChangeTextDocumentParams],
     "textDocument/didClose" -> Json.format[DidCloseTextDocumentParams],
     "textDocument/didSave" -> Json.format[DidSaveTextDocumentParams],
-    "workspace/didChangeWatchedFiles" -> Json.format[DidChangeWatchedFiles],
+    "workspace/didChangeWatchedFiles" -> Json.format[DidChangeWatchedFilesParams],
+    "workspace/didChangeConfiguration" -> Json.format[DidChangeConfigurationParams],
     "initialized" -> Initialized.format,
     "$/cancelRequest" -> Json.format[CancelRequest]
   )

--- a/metaserver/src/main/scala/scala/meta/languageserver/Configuration.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Configuration.scala
@@ -3,9 +3,9 @@ package scala.meta.languageserver
 import play.api.libs.json._
 
 case class Configuration(
-  scalafmtConfPath: String,
-  scalafixConfPath: String,
-  enableCompletions: Boolean,
+    scalafmtConfPath: String,
+    scalafixConfPath: String,
+    enableCompletions: Boolean,
 )
 object Configuration {
   implicit val format: OFormat[Configuration] = Json.format[Configuration]

--- a/metaserver/src/main/scala/scala/meta/languageserver/Configuration.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Configuration.scala
@@ -1,0 +1,12 @@
+package scala.meta.languageserver
+
+import play.api.libs.json._
+
+case class Configuration(
+  scalafmtConfPath: String,
+  scalafixConfPath: String,
+  enableCompletions: Boolean,
+)
+object Configuration {
+  implicit val format: OFormat[Configuration] = Json.format[Configuration]
+}

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
@@ -64,6 +64,9 @@ import org.langmeta.internal.semanticdb.XtensionDatabase
 import org.langmeta.internal.semanticdb.schema
 import org.langmeta.io.AbsolutePath
 import org.langmeta.semanticdb
+import play.api.libs.json.JsValue
+import play.api.libs.json.JsSuccess
+import play.api.libs.json.JsError
 
 case class ServerConfig(
     cwd: AbsolutePath,
@@ -224,6 +227,15 @@ class ScalametaLanguageServer(
         logger.warn(s"Unhandled file event: $event")
         ()
     }
+
+  override def onChangeConfiguration(settings: JsValue): Unit = {
+    (settings \ "scalameta").validate[Configuration] match {
+      case JsSuccess(value, _) =>
+        logger.info(s"Configuration changed $value")
+      case JsError(error) =>
+        logger.error(s"Can't decode configuration: $error")
+    }
+  }
 
   override def completion(
       request: TextDocumentCompletionRequest

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -14,6 +14,26 @@
         "onLanguage:scala"
     ],
     "contributes": {
+        "configuration": {
+            "title": "Scalameta Language Server",
+            "properties": {
+                "scalameta.scalafixConfPath": {
+                    "type": "string",
+                    "default": ".scalafix.conf",
+                    "description": "Path to the Scalafix configuration, relative to the workspace path"
+                },
+                "scalameta.scalafmtConfPath": {
+                    "type": "string",
+                    "default": ".scalafmt.conf",
+                    "description": "Path to the Scalafmt configuration, relative to the workspace path"
+                },
+                "scalameta.enableCompletions": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Enables completions as you type"
+                }
+            }
+        },
         "commands": [{
             "command": "scalameta.restartServer",
             "category": "Scalameta Language Server",

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -60,7 +60,8 @@ export async function activate(context: ExtensionContext) {
       fileEvents: [
         workspace.createFileSystemWatcher('**/*.semanticdb'),
         workspace.createFileSystemWatcher('**/*.compilerconfig')
-      ]
+      ],
+      configurationSection: "scalameta"
     },
     revealOutputChannelOn: RevealOutputChannelOn.Never
   };


### PR DESCRIPTION
Closes #6 

The purpose of this PR is purely to provide the infrastructure for this feature.
The configuration is decoded and logged, but not yet used.

It's also interesting to note that (at least in VSCode) the language client will send the current configuration right away when starting the server.