### PR TITLE
Move hover to semanticdb.

### DIFF
--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
@@ -291,15 +291,13 @@ class ScalametaLanguageServer(
 
   override def hover(
       request: TextDocumentHoverRequest
-  ): Task[Hover] = withPC {
-    scalac.getCompiler(request.params.textDocument) match {
-      case Some(g) =>
-        HoverProvider.hover(
-          g,
-          toPoint(request.params.textDocument, request.params.position)
-        )
-      case None => HoverProvider.empty
-    }
+  ): Task[Hover] = Task {
+    HoverProvider.hover(
+      symbolIndex,
+      Uri(request.params.textDocument),
+      request.params.position.line,
+      request.params.position.character
+    )
   }
 
   override def references(

--- a/metaserver/src/main/scala/scala/meta/languageserver/providers/HoverProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/providers/HoverProvider.scala
@@ -1,53 +1,203 @@
 package scala.meta.languageserver.providers
 
-import scala.tools.nsc.interactive.Global
-import scala.meta.languageserver.compiler.Cursor
-import scala.meta.languageserver.compiler.ScalacProvider
+import scala.meta.Type
+import scala.meta.languageserver.Uri
+import scala.meta.languageserver.search.SymbolIndex
+import scala.{meta => m}
+import scalafix.internal.util.DenotationOps
+import scalafix.internal.util.TypeSyntax
+import scalafix.rule.RuleCtx
+import scalafix.util.SemanticdbIndex
+import `scala`.meta.languageserver.index.SymbolData
+import com.typesafe.scalalogging.LazyLogging
 import langserver.messages.Hover
 import langserver.types.RawMarkedString
+import org.langmeta.internal.semanticdb.schema
 
-object HoverProvider {
+object HoverProvider extends LazyLogging {
   def empty: Hover = Hover(Nil, None)
+  val Template =
+    m.Template(Nil, Nil, m.Self(m.Name.Anonymous(), None), Nil)
 
   def hover(
-      compiler: Global,
-      cursor: Cursor
+      index: SymbolIndex,
+      uri: Uri,
+      line: Int,
+      column: Int
   ): Hover = {
-    val unit = ScalacProvider.addCompilationUnit(
-      global = compiler,
-      code = cursor.contents,
-      filename = cursor.uri.value,
-      cursor = None
-    )
-    val pos = unit.position(cursor.offset)
-    val typedTree = compiler.typedTreeAt(pos)
-    typeOfTree(compiler)(typedTree).fold(empty) { tpeName =>
+    val result = for {
+      (symbol, _) <- index.findSymbol(uri, line, column)
+      data <- index.data(symbol)
+      tpe <- getPrettyDefinition(symbol, data)
+      document <- index.documentIndex.getDocument(uri)
+    } yield {
+      val scalafixIndex = SemanticdbIndex.load(
+        schema.Database(document :: Nil).toDb(None),
+        m.Sourcepath(Nil),
+        m.Classpath(Nil)
+      )
+      val prettyTpe = new TypePrinter()(scalafixIndex).apply(tpe)
       Hover(
-        contents = List(
-          RawMarkedString(language = "scala", value = tpeName)
-        ),
+        contents = RawMarkedString(language = "scala", value = prettyTpe.syntax) :: Nil,
         range = None
       )
     }
+    result.getOrElse(Hover(Nil, None))
   }
 
-  private def typeOfTree(c: Global)(t: c.Tree): Option[String] = {
-    import c._
+  /** Returns a definition tree for this symbol signature */
+  private def getPrettyDefinition(
+      symbol: m.Symbol,
+      data: SymbolData
+  ): Option[m.Tree] = {
+    val denotation = m.Denotation(data.flags, data.name, data.signature, Nil)
+    val input = m.Input.Denotation(denotation.signature, symbol)
+    val mods = getMods(denotation)
+    val name = m.Term.Name(denotation.name)
+    val tname = m.Type.Name(denotation.name)
+    def parsedTpe: Option[Type] =
+      DenotationOps.defaultDialect(input).parse[m.Type].toOption
+    if (denotation.isVal) {
+      parsedTpe.map { tpe =>
+        m.Decl.Val(mods, m.Pat.Var(name) :: Nil, tpe)
+      }
+    } else if (denotation.isVar) {
 
-    val stringOrTree = t match {
-      case t: DefDef => Right(t.symbol.asMethod.info.toLongString)
-      case t: ValDef if t.tpt != null => Left(t.tpt)
-      case t: ValDef if t.rhs != null => Left(t.rhs)
-      case x => Left(x)
+      parsedTpe.collect {
+        case Type.Method((m.Term.Param(_, _, Some(tpe), _) :: Nil) :: Nil, _) =>
+          m.Decl.Var(
+            mods,
+            // TODO(olafur) fix https://github.com/scalameta/scalameta/issues/1100
+            m.Pat.Var(m.Term.Name(name.value.stripSuffix("_="))) :: Nil,
+            tpe
+          )
+      }
+    } else if (denotation.isDef) {
+      // turn method types into defs
+      // TODO(olafur) handle def macros
+      DenotationOps.defaultDialect(input).parse[m.Type].toOption.map {
+        case m.Type.Lambda(tparams, m.Type.Method(paramss, tpe)) =>
+          m.Decl.Def(mods, name, tparams, paramss, tpe)
+        case m.Type.Lambda(tparams, tpe) =>
+          m.Decl.Def(mods, name, tparams, Nil, tpe)
+        case m.Type.Method(paramss, tpe) =>
+          m.Decl.Def(mods, name, Nil, paramss, tpe)
+        case t => t
+      }
+    } else if (denotation.isPackageObject) {
+      symbol match {
+        case m.Symbol.Global(
+            m.Symbol.Global(_, m.Signature.Term(pkg)),
+            m.Signature.Term("package")
+            ) =>
+          Some(m.Pkg.Object(mods, m.Term.Name(pkg), Template))
+        case _ =>
+          logger.warn(s"Unexpected package object symbol: $symbol")
+          None
+      }
+    } else if (denotation.isType && denotation.isAbstract) {
+      Some(
+        m.Decl.Type(
+          mods.filterNot(_.is[m.Mod.Abstract]),
+          tname,
+          Nil,
+          m.Type.Bounds(None, None)
+        )
+      )
+    } else if (denotation.isType) {
+      parsedTpe.map {
+        case m.Type.Lambda(tparams, tpe) =>
+          m.Defn.Type(mods, tname, tparams, tpe)
+        case tpe =>
+          m.Defn.Type(mods, tname, Nil, tpe)
+      }
+    } else if (denotation.isObject) {
+      Some(m.Defn.Object(mods.filterNot(_.is[m.Mod.Final]), name, Template))
+    } else if (denotation.isClass) {
+      Some(
+        m.Defn.Class(
+          mods,
+          tname,
+          Nil,
+          m.Ctor.Primary(Nil, m.Name.Anonymous(), Nil),
+          Template
+        )
+      )
+    } else if (denotation.isTrait) {
+      Some(
+        m.Defn.Trait(
+          mods,
+          tname,
+          Nil,
+          m.Ctor.Primary(Nil, m.Name.Anonymous(), Nil),
+          Template
+        )
+      )
+    } else if (denotation.isPackage) {
+      Some(m.Pkg(name, Nil))
+    } else if (!denotation.signature.isEmpty) {
+      parsedTpe
+    } else {
+      Some(m.Type.Name(data.name))
     }
-
-    stringOrTree match {
-      case Right(string) => Some(string)
-      case Left(null) => None
-      case Left(tree) if tree.tpe ne NoType => Some(tree.tpe.widen.toString)
-      case _ => None
-    }
-
   }
 
+  private def getMods(denotation: m.Denotation): List[m.Mod] = {
+    import denotation._
+    import scala.meta._
+    val buf = List.newBuilder[m.Mod]
+    if (isPrivate) buf += mod"private"
+    if (isProtected) buf += mod"protected"
+    if (isFinal) buf += mod"final"
+    if (isAbstract) buf += mod"abstract"
+    if (isImplicit) buf += mod"implicit"
+    if (isLazy) buf += mod"lazy"
+    if (isSealed) buf += mod"sealed"
+    buf.result()
+  }
+
+  /** Pretty-prints types in a given tree
+   *
+   * Uses the scalafix TypeSyntax, the same one used by ExplicitResultTypes.
+   * It's quite primitive for now, but the plan is to implement fancy
+   * stuff in the future like scope aware printing taking into
+   * account renames etc.
+   */
+  private class TypePrinter(implicit scalafixIndex: SemanticdbIndex)
+      extends m.Transformer {
+    private def pretty(tpe: m.Type): m.Tree = {
+      val printed =
+        TypeSyntax.prettify(tpe, RuleCtx(m.Lit.Null()), shortenNames = true)._1
+      InfixSymbolicTypes.apply(printed)
+    }
+
+    override def apply(tree: m.Tree): m.Tree = tree match {
+      case tpe: m.Type => {
+        pretty(tpe)
+      }
+      case _ => super.apply(tree)
+    }
+  }
+
+  /** Makes all symbolic type binary operators infix */
+  private object InfixSymbolicTypes extends m.Transformer {
+    private object SymbolicType {
+      def unapply(arg: m.Type): Option[m.Type.Name] = arg match {
+        case nme @ m.Type.Name(name) =>
+          if (!name.isEmpty &&
+            !Character.isJavaIdentifierStart(name.charAt(0))) {
+            Some(nme)
+          } else None
+        case _ => None
+      }
+    }
+    override def apply(tree: m.Tree): m.Tree = {
+      val next = tree match {
+        case m.Type.Apply(SymbolicType(name), lhs :: rhs :: Nil) =>
+          m.Type.ApplyInfix(lhs, name, rhs)
+        case t => t
+      }
+      super.apply(next)
+    }
+  }
 }

--- a/metaserver/src/main/scala/scala/meta/languageserver/search/InMemorySymbolIndex.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/search/InMemorySymbolIndex.scala
@@ -91,6 +91,9 @@ class InMemorySymbolIndex(
       }
   }
 
+  def data(symbol: Symbol): Option[SymbolData] =
+    symbolIndexer.get(symbol)
+
   /** Returns symbol references data from the index taking into account relevant alternatives */
   def referencesData(
       symbol: Symbol

--- a/metaserver/src/main/scala/scala/meta/languageserver/search/SymbolIndex.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/search/SymbolIndex.scala
@@ -30,6 +30,9 @@ trait SymbolIndex extends LazyLogging {
       data <- definitionData(symbol)
     } yield edit.toRevisedDefinition(data)
 
+  /** Returns symbol data for this exact Symbol */
+  def data(symbol: Symbol): Option[SymbolData]
+
   /** Returns symbol references data from the index taking into account relevant alternatives */
   def referencesData(symbol: Symbol): List[SymbolData]
 
@@ -51,6 +54,8 @@ trait SymbolIndex extends LazyLogging {
 
   /** Remove any persisted files from index returning to a clean start */
   def clearIndex(): Unit
+
+  def documentIndex: DocumentIndex
 
 }
 

--- a/metaserver/src/test/scala/tests/hover/BaseHoverTest.scala
+++ b/metaserver/src/test/scala/tests/hover/BaseHoverTest.scala
@@ -1,0 +1,64 @@
+package tests.hover
+
+import scala.meta.languageserver.Uri
+import scala.meta.languageserver.providers.HoverProvider
+import scala.{meta => m}
+import langserver.messages.Hover
+import play.api.libs.json.Json
+import tests.search.BaseIndexTest
+
+abstract class BaseHoverTest extends BaseIndexTest {
+
+  def check(
+      filename: String,
+      code: String,
+      f: Hover => Unit
+  ): Unit = {
+    targeted(
+      filename,
+      code, { point =>
+        val uri = Uri.file(filename)
+        val input = m.Input.VirtualFile(uri.value, point.contents)
+        val pos = m.Position.Range(input, point.offset, point.offset)
+        indexInput(uri, point.contents)
+        val result =
+          HoverProvider.hover(symbols, uri, pos.startLine, pos.startColumn)
+        f(result)
+      }
+    )
+
+  }
+
+  def check(
+      filename: String,
+      code: String,
+      expectedValue: String
+  ): Unit = {
+    check(
+      filename,
+      code, { result =>
+        val obtained = Json.prettyPrint(Json.toJson(result))
+        val expected =
+          s"""{
+             |  "contents" : [ {
+             |    "language" : "scala",
+             |    "value" : "$expectedValue"
+             |  } ]
+             |}""".stripMargin
+        assertNoDiff(obtained, expected)
+      }
+    )
+  }
+
+  def checkMissing(
+      filename: String,
+      code: String
+  ): Unit = {
+    check(
+      filename,
+      code, { result =>
+        assert(result.contents.isEmpty)
+      }
+    )
+  }
+}

--- a/metaserver/src/test/scala/tests/hover/HoverTest.scala
+++ b/metaserver/src/test/scala/tests/hover/HoverTest.scala
@@ -156,7 +156,6 @@ object HoverTest extends BaseHoverTest {
     "val increment: (Int, String)"
   )
 
-  //  val x: Tuple2[]
   check(
     "TupleN",
     """

--- a/metaserver/src/test/scala/tests/hover/HoverTest.scala
+++ b/metaserver/src/test/scala/tests/hover/HoverTest.scala
@@ -1,44 +1,6 @@
-package tests.compiler
+package tests.hover
 
-import scala.meta.languageserver.providers.HoverProvider
-import play.api.libs.json.Json
-
-object HoverTest extends CompilerSuite {
-
-  def check(
-      filename: String,
-      code: String,
-      expectedValue: String
-  ): Unit = {
-    targeted(
-      filename,
-      code, { point =>
-        val result = HoverProvider.hover(compiler, point)
-        val obtained = Json.prettyPrint(Json.toJson(result))
-        val expected =
-          s"""{
-             |  "contents" : [ {
-             |    "language" : "scala",
-             |    "value" : "$expectedValue"
-             |  } ]
-             |}""".stripMargin
-        assertNoDiff(obtained, expected)
-      }
-    )
-  }
-
-  def checkMissing(
-      filename: String,
-      code: String
-  ): Unit = {
-    targeted(
-      filename,
-      code, { point =>
-        val result = HoverProvider.hover(compiler, point)
-        assert(result.contents.isEmpty)
-      }
-    )
-  }
+object HoverTest extends BaseHoverTest {
 
   check(
     "val assignment",
@@ -47,100 +9,119 @@ object HoverTest extends CompilerSuite {
       |  val <<x>> = List(Some(1), Some(2), Some(3))
       |}
     """.stripMargin,
-    "List[Some[Int]]"
+    "val x: List[Some[Int]]"
   )
 
   check(
     "val assignment type annotation",
     """
-      |object a {
+      |object b {
       |  val <<x>>: List[Option[Int]] = List(Some(1), Some(2), Some(3))
       |}
     """.stripMargin,
-    "List[Option[Int]]"
+    "val x: List[Option[Int]]"
   )
 
   check(
     "var assignment",
     """
-      |object a {
+      |object c {
       |  var <<x>> = List(Some(1), Some(2), Some(3))
       |}
     """.stripMargin,
-    "List[Some[Int]]"
+    "var x: List[Some[Int]]"
   )
 
   check(
     "var assignment type annotation",
     """
-      |object a {
+      |object d {
       |  var <<x>>: List[Option[Int]] = List(Some(1), Some(2), Some(3))
       |}
     """.stripMargin,
-    "List[Option[Int]]"
+    "var x: List[Option[Int]]"
   )
 
   check(
     "select",
     """
-      |object a {
+      |object e {
       |  val x = List(1, 2, 3)
       |  <<x>>.mkString
       |}
     """.stripMargin,
-    "List[Int]"
+    "val x: List[Int]"
   )
 
-  check(
+  checkMissing( // TODO(olafur) fall back to tokenizer
     "literal Int",
     """
-      |object a {
+      |object f {
       |  val x = <<42>>
       |}
     """.stripMargin,
-    "Int"
   )
 
   check(
     "case class apply",
     """
-      |object a {
+      |object g {
       |  case class User(name: String, age: Int)
       |  val user = <<User>>("test", 42)
       |}
     """.stripMargin,
-    "(name: String, age: Int)a.User"
+    "object User"
   )
 
   check(
     "case class parameters",
     """
-      |object a {
+      |object h {
       |  case class User(<<name>>: String, age: Int)
       |}
     """.stripMargin,
-    "String"
+    "val name: String"
   )
 
   check(
     "def",
     """
-      |object a {
+      |object i {
       |  def <<test>>(x: String, y: List[Int]) = y.mkString.length
       |}
     """.stripMargin,
-    "(x: String, y: List[Int])Int"
+    "def test(x: String, y: List[Int]): Int"
+  )
+
+  check(
+    "def with type parameters",
+    """
+      |object i2 {
+      |  def <<test>>[T](lst: List[T]) = lst.tail
+      |}
+    """.stripMargin,
+    "def test[T](lst: List[T]): List[T]"
+  )
+
+  check(
+    "curried def",
+    """
+      |object i3 {
+      |  def <<curry>>[T](init: T)(f: T => T): T =  ???
+      |}
+    """.stripMargin,
+    "def curry[T](init: T)(f: T => T): T"
   )
 
   check(
     "def call site",
     """
-      |object a {
+      |object j {
       |  def test(x: String, y: List[Int]) = y.mkString.length
       |  <<test>>("foo", Nil)
       |}
     """.stripMargin,
-    "(x: String, y: List[Int])Int"
+    "def test(x: String, y: List[Int]): Int"
   )
 
   checkMissing(
@@ -150,12 +131,173 @@ object HoverTest extends CompilerSuite {
     """.stripMargin
   )
 
-  // FIXME(gabro): this should return "A"
   checkMissing(
-    "class",
+    "comments",
     """
-      |class <<A>>(x: Int, y: String)
+      |class B(x: Int, y: String) // <<good>>
     """.stripMargin
   )
 
+  check(
+    "class",
+    """
+      |class <<C>>(x: Int, y: String)
+    """.stripMargin,
+    "class C"
+  )
+
+  check(
+    "tuple literal",
+    """
+      |object l {
+      |  val <<increment>>: (Int, String) = ???
+      |}
+    """.stripMargin,
+    "val increment: (Int, String)"
+  )
+
+  //  val x: Tuple2[]
+  check(
+    "TupleN",
+    """
+      |object m {
+      |  val <<increment>>: Tuple2[Int, String] = ???
+      |}
+    """.stripMargin,
+    "val increment: (Int, String)"
+  )
+
+  check(
+    "function literal",
+    """
+      |object n {
+      |  val <<increment>>: Int => Int = _ + 1
+      |}
+    """.stripMargin,
+    "val increment: Int => Int"
+  )
+
+  check(
+    "FunctionN",
+    """
+      |object o {
+      |  val <<increment>>: Function[Int, String] = _.toString
+      |}
+    """.stripMargin,
+    "val increment: Function[Int, String]"
+  )
+
+  // TODO(olafur) named arguments are not handled in InteractiveSemanticdb
+  checkMissing(
+    "named args",
+    """
+      |object p {
+      |  val foo = Left(<<value>> = 2)
+      |}
+    """.stripMargin
+  )
+
+  check(
+    "symbolic infix",
+    """
+      |object q {
+      |  type :+:[A, B] = Map[A, B]
+      |  val <<infix>>: :+:[Map[Int, String], :+:[Int, String]] = ???
+      |}
+    """.stripMargin,
+    "val infix: Map[Int, String] :+: Int :+: String"
+  )
+
+  check(
+    "pattern",
+    """
+      |object r {
+      |  List(1) match { case <<x>> :: Nil => }
+      |}
+    """.stripMargin,
+    "val x: Int"
+  )
+
+  check(
+    "pattern 2",
+    """
+      |object r2 {
+      |  List(1) match { case List(<<x>>) => }
+      |}
+    """.stripMargin,
+    "val x: Int"
+  )
+
+  check(
+    "imports",
+    """
+      |import scala.concurrent.<<Future>>
+      |object s {
+      |  val x: Future[Int] = Future.successful(1)
+      |}
+    """.stripMargin,
+    "object Future" // TODO(olafur) handle Symbol.Multi
+  )
+
+  check(
+    "params",
+    """
+      |object v {
+      |  List(1).foreach(<<x>> => println(x))
+      |}
+    """.stripMargin,
+    "Int"
+  )
+
+  check(
+    "for comprehension",
+    """
+      |object t {
+      |  for {
+      |    x <- List(1)
+      |    z <- 1.to(x)
+      |  } yield <<z>>
+      |}
+    """.stripMargin,
+    "Int"
+  )
+
+  check(
+    "package",
+    """
+      |object w {
+      |  <<scala>>.Left(1)
+      |}
+    """.stripMargin,
+    "package scala"
+  )
+
+  check(
+    "package object",
+    """
+      |package object <<pkg>>
+    """.stripMargin,
+    // TODO(olafur) make <<math>>.max(1, 2) resolve to package object math
+    "package object pkg"
+  )
+
+  check(
+    "type alias",
+    """
+      |object v {
+      |  type <<F>>[T] = Option[T]
+      |}
+    """.stripMargin,
+    "type F[T] = Option[T]"
+  )
+
+  check(
+    "abstract type alias",
+    """
+      |object v2 {
+      |  type <<F>>[T] <: Any
+      |}
+    """.stripMargin,
+    "type F"
+  )
 }

--- a/metaserver/src/test/scala/tests/search/BaseIndexTest.scala
+++ b/metaserver/src/test/scala/tests/search/BaseIndexTest.scala
@@ -1,0 +1,44 @@
+package tests.search
+
+import scala.meta.interactive.InteractiveSemanticdb
+import scala.meta.internal.inputs._
+import scala.meta.languageserver.Buffers
+import scala.meta.languageserver.Effects
+import scala.meta.languageserver.ServerConfig
+import scala.meta.languageserver.Uri
+import scala.meta.languageserver.search.SymbolIndex
+import scala.{meta => m}
+import langserver.core.Notifications
+import org.langmeta.internal.io.PathIO
+import org.langmeta.internal.semanticdb._
+import tests.compiler.CompilerSuite
+
+abstract class BaseIndexTest extends CompilerSuite {
+  val buffers = Buffers()
+  val symbols = SymbolIndex(
+    PathIO.workingDirectory,
+    Notifications.empty,
+    buffers,
+    ServerConfig(PathIO.workingDirectory)
+  )
+  def indexDocument(document: m.Document): Effects.IndexSemanticdb =
+    symbols.indexDatabase(
+      m.Database(document :: Nil).toSchema(PathIO.workingDirectory)
+    )
+  def indexInput(uri: Uri, code: String): m.Document = {
+    buffers.changed(m.Input.VirtualFile(uri.value, code))
+    val document =
+      InteractiveSemanticdb.toDocument(compiler, code, uri.value, 10000)
+    Predef.assert(
+      document.messages.isEmpty, {
+        val messages = document.messages
+          .map(m => m.position.formatMessage(m.severity.toString(), m.text))
+          .mkString("\n\n")
+        s"Expected no compile errors/warnings, got:\n$messages"
+      }
+    )
+    indexDocument(document)
+    document
+  }
+
+}


### PR DESCRIPTION
Fixes #148 

![2017-12-23 15 12 22](https://user-images.githubusercontent.com/1408093/34320516-e6ca412a-e7f3-11e7-8cb9-579d58b709c1.gif)

Instead of showing only the type I opted to do the same as the Java Language Server and also include modifiers like `implicit val` or `final class` or `private object`. It's sometimes a bit weird, like variables bound in patterns get `val`, but I personally find this a nice improvement. 