### PR TITLE
Refactor server around configuration Observable

### DIFF
--- a/metaserver/src/main/scala/scala/meta/languageserver/Configuration.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Configuration.scala
@@ -11,12 +11,12 @@ import Configuration._
 import play.api.libs.json.OFormat
 
 case class Configuration(
-  scalafmt: Scalafmt = Scalafmt(),
-  scalafix: Scalafix = Scalafix(),
-  search: Search = Search(),
-  experimental: Experimental = Experimental(),
-  hover: Hover = Hover(),
-  rename: Rename = Rename(),
+    scalafmt: Scalafmt = Scalafmt(),
+    scalafix: Scalafix = Scalafix(),
+    search: Search = Search(),
+    experimental: Experimental = Experimental(),
+    hover: Hover = Hover(),
+    rename: Rename = Rename(),
 )
 
 object Configuration {
@@ -28,8 +28,14 @@ object Configuration {
   case class Hover(enabled: Boolean = false)
   case class Rename(enabled: Boolean = false)
 
-  case class Scalafmt(enabled: Boolean = true, confPath: RelativePath = RelativePath(".scalafmt.conf"))
-  case class Scalafix(enabled: Boolean = true, confPath: RelativePath = RelativePath(".scalafix.conf"))
+  case class Scalafmt(
+      enabled: Boolean = true,
+      confPath: RelativePath = RelativePath(".scalafmt.conf")
+  )
+  case class Scalafix(
+      enabled: Boolean = true,
+      confPath: RelativePath = RelativePath(".scalafix.conf")
+  )
   // TODO(olafur): re-enable indexJDK after https://github.com/scalameta/language-server/issues/43 is fixed
   case class Search(indexJDK: Boolean = false, indexClasspath: Boolean = true)
 
@@ -47,25 +53,33 @@ object Configuration {
   // TODO(gabro): Json.format[A] is tedious to write.
   // We should use an annotation macro to cut the boilerplate
   object Scalac {
-    implicit val format: OFormat[Scalac] = Json.using[Json.WithDefaultValues].format[Scalac]
+    implicit val format: OFormat[Scalac] =
+      Json.using[Json.WithDefaultValues].format[Scalac]
   }
   object Hover {
-    implicit val format: OFormat[Hover] = Json.using[Json.WithDefaultValues].format[Hover]
+    implicit val format: OFormat[Hover] =
+      Json.using[Json.WithDefaultValues].format[Hover]
   }
   object Rename {
-    implicit val format: OFormat[Rename] = Json.using[Json.WithDefaultValues].format[Rename]
+    implicit val format: OFormat[Rename] =
+      Json.using[Json.WithDefaultValues].format[Rename]
   }
   object Experimental {
-    implicit val format: OFormat[Experimental] = Json.using[Json.WithDefaultValues].format[Experimental]
+    implicit val format: OFormat[Experimental] =
+      Json.using[Json.WithDefaultValues].format[Experimental]
   }
   object Scalafmt {
-    implicit val format: OFormat[Scalafmt] = Json.using[Json.WithDefaultValues].format[Scalafmt]
+    implicit val format: OFormat[Scalafmt] =
+      Json.using[Json.WithDefaultValues].format[Scalafmt]
   }
   object Scalafix {
-    implicit val format: OFormat[Scalafix] = Json.using[Json.WithDefaultValues].format[Scalafix]
+    implicit val format: OFormat[Scalafix] =
+      Json.using[Json.WithDefaultValues].format[Scalafix]
   }
   object Search {
-    implicit val format: OFormat[Search] = Json.using[Json.WithDefaultValues].format[Search]
+    implicit val format: OFormat[Search] =
+      Json.using[Json.WithDefaultValues].format[Search]
   }
-  implicit val format: OFormat[Configuration] = Json.using[Json.WithDefaultValues].format[Configuration]
+  implicit val format: OFormat[Configuration] =
+    Json.using[Json.WithDefaultValues].format[Configuration]
 }

--- a/metaserver/src/main/scala/scala/meta/languageserver/Configuration.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Configuration.scala
@@ -13,25 +13,25 @@ import play.api.libs.json.OFormat
 case class Configuration(
   scalafmt: Scalafmt = Scalafmt(),
   scalafix: Scalafix = Scalafix(),
-  indexing: Indexing = Indexing(),
-  experimental: Experimental = Experimental()
+  search: Search = Search(),
+  experimental: Experimental = Experimental(),
+  hover: Hover = Hover(),
+  rename: Rename = Rename(),
 )
 
 object Configuration {
 
   case class Experimental(
-      completions: Completions = Completions(),
-      hover: Hover = Hover(),
-      rename: Rename = Rename()
+      scalac: Scalac = Scalac(),
   )
-  case class Completions(enable: Boolean = false)
-  case class Hover(enable: Boolean = false)
-  case class Rename(enable: Boolean = false)
+  case class Scalac(enableCompletions: Boolean = false)
+  case class Hover(enabled: Boolean = false)
+  case class Rename(enabled: Boolean = false)
 
-  case class Scalafmt(enable: Boolean = true, confPath: RelativePath = RelativePath(".scalafmt.conf"))
-  case class Scalafix(enable: Boolean = true, confPath: RelativePath = RelativePath(".scalafix.conf"))
+  case class Scalafmt(enabled: Boolean = true, confPath: RelativePath = RelativePath(".scalafmt.conf"))
+  case class Scalafix(enabled: Boolean = true, confPath: RelativePath = RelativePath(".scalafix.conf"))
   // TODO(olafur): re-enable indexJDK after https://github.com/scalameta/language-server/issues/43 is fixed
-  case class Indexing(jdk: Boolean = false, classpath: Boolean = true)
+  case class Search(indexJDK: Boolean = false, indexClasspath: Boolean = true)
 
   implicit val absolutePathReads: Reads[AbsolutePath] =
     Reads.StringReads
@@ -46,8 +46,8 @@ object Configuration {
 
   // TODO(gabro): Json.format[A] is tedious to write.
   // We should use an annotation macro to cut the boilerplate
-  object Completions {
-    implicit val format: OFormat[Completions] = Json.using[Json.WithDefaultValues].format[Completions]
+  object Scalac {
+    implicit val format: OFormat[Scalac] = Json.using[Json.WithDefaultValues].format[Scalac]
   }
   object Hover {
     implicit val format: OFormat[Hover] = Json.using[Json.WithDefaultValues].format[Hover]
@@ -64,8 +64,8 @@ object Configuration {
   object Scalafix {
     implicit val format: OFormat[Scalafix] = Json.using[Json.WithDefaultValues].format[Scalafix]
   }
-  object Indexing {
-    implicit val format: OFormat[Indexing] = Json.using[Json.WithDefaultValues].format[Indexing]
+  object Search {
+    implicit val format: OFormat[Search] = Json.using[Json.WithDefaultValues].format[Search]
   }
   implicit val format: OFormat[Configuration] = Json.using[Json.WithDefaultValues].format[Configuration]
 }

--- a/metaserver/src/main/scala/scala/meta/languageserver/Configuration.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Configuration.scala
@@ -1,12 +1,73 @@
 package scala.meta.languageserver
 
 import play.api.libs.json._
+import play.api.libs.functional.syntax._
+
+import org.langmeta.AbsolutePath
+import org.langmeta.RelativePath
+import java.nio.file.Paths
+
+import Configuration._
+import play.api.libs.json.OFormat
+import scala.meta.languageserver.Configuration
+import scala.meta.languageserver.Configuration.{ Completions, Experimental, Hover, Indexing, Rename, Scalafix, Scalafmt }
 
 case class Configuration(
-    scalafmtConfPath: String,
-    scalafixConfPath: String,
-    enableCompletions: Boolean,
+  scalafmt: Scalafmt = Scalafmt(),
+  scalafix: Scalafix = Scalafix(),
+  indexing: Indexing = Indexing(),
+  experimental: Experimental = Experimental()
 )
+
 object Configuration {
+
+  case class Experimental(
+      completions: Completions = Completions(),
+      hover: Hover = Hover(),
+      rename: Rename = Rename()
+  )
+  case class Completions(enable: Boolean = false)
+  case class Hover(enable: Boolean = false)
+  case class Rename(enable: Boolean = false)
+
+  case class Scalafmt(enable: Boolean = true, confPath: RelativePath = RelativePath(".scalafmt.conf"))
+  case class Scalafix(enable: Boolean = true, confPath: RelativePath = RelativePath(".scalafix.conf"))
+  // TODO(olafur): re-enable indexJDK after https://github.com/scalameta/language-server/issues/43 is fixed
+  case class Indexing(jdk: Boolean = false, classpath: Boolean = true)
+
+  implicit val absolutePathReads: Reads[AbsolutePath] =
+    Reads.StringReads
+      .filter(s => Paths.get(s).isAbsolute)
+      .map(AbsolutePath(_))
+  implicit val absolutePathWrites: Writes[AbsolutePath] =
+    Writes.StringWrites.contramap(_.toString)
+  implicit val relativePathReads: Reads[RelativePath] =
+    Reads.StringReads.map(RelativePath(_))
+  implicit val relativePathWrites: Writes[RelativePath] =
+    Writes.StringWrites.contramap(_.toString)
+
+  // TODO(gabro): Json.format[A] is tedious to write.
+  // We should use an annotation macro to cut the boilerplate
+  object Completions {
+    implicit val format: OFormat[Completions] = Json.using[Json.WithDefaultValues].format[Completions]
+  }
+  object Hover {
+    implicit val format: OFormat[Hover] = Json.format[Hover]
+  }
+  object Rename {
+    implicit val format: OFormat[Rename] = Json.format[Rename]
+  }
+  object Experimental {
+    implicit val format: OFormat[Experimental] = Json.format[Experimental]
+  }
+  object Scalafmt {
+    implicit val format: OFormat[Scalafmt] = Json.format[Scalafmt]
+  }
+  object Scalafix {
+    implicit val format: OFormat[Scalafix] = Json.format[Scalafix]
+  }
+  object Indexing {
+    implicit val format: OFormat[Indexing] = Json.format[Indexing]
+  }
   implicit val format: OFormat[Configuration] = Json.format[Configuration]
 }

--- a/metaserver/src/main/scala/scala/meta/languageserver/Configuration.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Configuration.scala
@@ -29,8 +29,8 @@ object Configuration {
   case class Rename(enabled: Boolean = false)
 
   case class Scalafmt(
-      enabled: Boolean = true,
-      confPath: RelativePath = RelativePath(".scalafmt.conf")
+      version: String = "1.3.0",
+      confPath: Option[RelativePath] = None
   )
   case class Scalafix(
       enabled: Boolean = true,
@@ -69,6 +69,7 @@ object Configuration {
       Json.using[Json.WithDefaultValues].format[Experimental]
   }
   object Scalafmt {
+    lazy val DefaultConf = RelativePath(".scalafmt.conf")
     implicit val format: OFormat[Scalafmt] =
       Json.using[Json.WithDefaultValues].format[Scalafmt]
   }

--- a/metaserver/src/main/scala/scala/meta/languageserver/Configuration.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Configuration.scala
@@ -11,24 +11,22 @@ import Configuration._
 import play.api.libs.json.OFormat
 
 case class Configuration(
+    scalac: Scalac = Scalac(),
     scalafmt: Scalafmt = Scalafmt(),
     scalafix: Scalafix = Scalafix(),
     search: Search = Search(),
-    experimental: Experimental = Experimental(),
     hover: Hover = Hover(),
     rename: Rename = Rename(),
 )
 
 object Configuration {
 
-  case class Experimental(
-      scalac: Scalac = Scalac(),
-  )
-  case class Scalac(enableCompletions: Boolean = false)
+  case class Scalac(enabled: Boolean = false)
   case class Hover(enabled: Boolean = false)
   case class Rename(enabled: Boolean = false)
 
   case class Scalafmt(
+      enabled: Boolean = true,
       version: String = "1.3.0",
       confPath: Option[RelativePath] = None
   )
@@ -64,12 +62,8 @@ object Configuration {
     implicit val format: OFormat[Rename] =
       Json.using[Json.WithDefaultValues].format[Rename]
   }
-  object Experimental {
-    implicit val format: OFormat[Experimental] =
-      Json.using[Json.WithDefaultValues].format[Experimental]
-  }
   object Scalafmt {
-    lazy val DefaultConf = RelativePath(".scalafmt.conf")
+    lazy val defaultConfPath = RelativePath(".scalafmt.conf")
     implicit val format: OFormat[Scalafmt] =
       Json.using[Json.WithDefaultValues].format[Scalafmt]
   }

--- a/metaserver/src/main/scala/scala/meta/languageserver/Configuration.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Configuration.scala
@@ -9,8 +9,6 @@ import java.nio.file.Paths
 
 import Configuration._
 import play.api.libs.json.OFormat
-import scala.meta.languageserver.Configuration
-import scala.meta.languageserver.Configuration.{ Completions, Experimental, Hover, Indexing, Rename, Scalafix, Scalafmt }
 
 case class Configuration(
   scalafmt: Scalafmt = Scalafmt(),

--- a/metaserver/src/main/scala/scala/meta/languageserver/Configuration.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Configuration.scala
@@ -50,22 +50,22 @@ object Configuration {
     implicit val format: OFormat[Completions] = Json.using[Json.WithDefaultValues].format[Completions]
   }
   object Hover {
-    implicit val format: OFormat[Hover] = Json.format[Hover]
+    implicit val format: OFormat[Hover] = Json.using[Json.WithDefaultValues].format[Hover]
   }
   object Rename {
-    implicit val format: OFormat[Rename] = Json.format[Rename]
+    implicit val format: OFormat[Rename] = Json.using[Json.WithDefaultValues].format[Rename]
   }
   object Experimental {
-    implicit val format: OFormat[Experimental] = Json.format[Experimental]
+    implicit val format: OFormat[Experimental] = Json.using[Json.WithDefaultValues].format[Experimental]
   }
   object Scalafmt {
-    implicit val format: OFormat[Scalafmt] = Json.format[Scalafmt]
+    implicit val format: OFormat[Scalafmt] = Json.using[Json.WithDefaultValues].format[Scalafmt]
   }
   object Scalafix {
-    implicit val format: OFormat[Scalafix] = Json.format[Scalafix]
+    implicit val format: OFormat[Scalafix] = Json.using[Json.WithDefaultValues].format[Scalafix]
   }
   object Indexing {
-    implicit val format: OFormat[Indexing] = Json.format[Indexing]
+    implicit val format: OFormat[Indexing] = Json.using[Json.WithDefaultValues].format[Indexing]
   }
-  implicit val format: OFormat[Configuration] = Json.format[Configuration]
+  implicit val format: OFormat[Configuration] = Json.using[Json.WithDefaultValues].format[Configuration]
 }

--- a/metaserver/src/main/scala/scala/meta/languageserver/Formatter.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Formatter.scala
@@ -19,7 +19,7 @@ abstract class Formatter {
 object Formatter extends LazyLogging {
 
   /** Returns formatter that does nothing */
-  def noop: Formatter = new Formatter {
+  lazy val noop: Formatter = new Formatter {
     override def format(
         code: String,
         filename: String,

--- a/metaserver/src/main/scala/scala/meta/languageserver/Main.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Main.scala
@@ -14,10 +14,11 @@ import org.langmeta.internal.io.PathIO
 object Main extends LazyLogging {
   def main(args: Array[String]): Unit = {
     val cwd = PathIO.workingDirectory
-    val config = ServerConfig(cwd)
-    Files.createDirectories(config.configDir.toNIO)
-    val out = new PrintStream(new FileOutputStream(config.logFile))
-    val err = new PrintStream(new FileOutputStream(config.logFile))
+    val configDir = cwd.resolve(".metaserver").toNIO
+    val logFile = configDir.resolve("metaserver.log").toFile
+    Files.createDirectories(configDir)
+    val out = new PrintStream(new FileOutputStream(logFile))
+    val err = new PrintStream(new FileOutputStream(logFile))
     val stdin = System.in
     val stdout = System.out
     val stderr = System.err
@@ -30,7 +31,7 @@ object Main extends LazyLogging {
       System.setErr(err)
       logger.info(s"Starting server in $cwd")
       logger.info(s"Classpath: ${Properties.javaClassPath}")
-      val server = new ScalametaLanguageServer(config, stdin, stdout, out)
+      val server = new ScalametaLanguageServer(cwd, stdin, stdout, out)
       LSPLogger.connection = Some(server.connection)
       server.start()
     } catch {

--- a/metaserver/src/main/scala/scala/meta/languageserver/MonixEnrichments.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/MonixEnrichments.scala
@@ -1,0 +1,24 @@
+package scala.meta.languageserver
+
+import scala.concurrent.Future
+import monix.execution.Ack
+import monix.execution.Scheduler
+import monix.reactive.Observable
+import monix.reactive.observers.Subscriber
+
+object MonixEnrichments {
+  implicit class XtensionObservableScalameta[A](val o: Observable[A])
+      extends AnyVal {
+    def onNext[B](f: (Subscriber[B], A) => Future[Ack]): Observable[B] = {
+      o.liftByOperator[B] { out =>
+        new Subscriber[A] {
+          override implicit def scheduler: Scheduler = out.scheduler
+          override def onError(ex: Throwable): Unit = out.onError(ex)
+          override def onComplete(): Unit = out.onComplete()
+          override def onNext(elem: A): Future[Ack] = f(out, elem)
+        }
+      }
+    }
+  }
+
+}

--- a/metaserver/src/main/scala/scala/meta/languageserver/MonixEnrichments.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/MonixEnrichments.scala
@@ -1,24 +1,49 @@
 package scala.meta.languageserver
 
-import scala.concurrent.Future
-import monix.execution.Ack
+import monix.execution.Cancelable
 import monix.execution.Scheduler
 import monix.reactive.Observable
-import monix.reactive.observers.Subscriber
 
 object MonixEnrichments {
-  implicit class XtensionObservableScalameta[A](val o: Observable[A])
-      extends AnyVal {
-    def onNext[B](f: (Subscriber[B], A) => Future[Ack]): Observable[B] = {
-      o.liftByOperator[B] { out =>
-        new Subscriber[A] {
-          override implicit def scheduler: Scheduler = out.scheduler
-          override def onError(ex: Throwable): Unit = out.onError(ex)
-          override def onComplete(): Unit = out.onComplete()
-          override def onNext(elem: A): Future[Ack] = f(out, elem)
-        }
+
+  /**
+   * Utility to read the latest eagerly computed value from an observable.
+   *
+   * NOTE. Immediately subscribes to the value and eagerly computes the value on every update.
+   * Subscription can be cancelled with .cancel()
+   *
+   * @param obs The observable to convert into a reactive variable.
+   * @param s The scheduler to compute the variable on.
+   */
+  class ObservableCurrentValue[+A](obs: Observable[A])(implicit s: Scheduler)
+      extends (() => A)
+      with Cancelable {
+    private var value: Any = _
+    private val cancelable = obs.foreach(newValue => value = newValue)
+    override def apply(): A = {
+      if (value == null) {
+        throw new NoSuchElementException(
+          "Reading from empty Observable, consider using MulticastStrategy.behavior(initialValue)"
+        )
+      } else {
+        value.asInstanceOf[A]
       }
     }
+    override def cancel(): Unit = cancelable.cancel()
+  }
+
+  implicit class XtensionObservable[A](val obs: Observable[A]) extends AnyVal {
+
+    def focus[B](f: A => B): Observable[B] =
+      obs.distinctUntilChangedByKey(f).map(f)
+
+    def toFunction0()(implicit s: Scheduler): () => A =
+      toObservableCurrentValue()
+
+    def toObservableCurrentValue()(
+        implicit s: Scheduler
+    ): ObservableCurrentValue[A] =
+      new ObservableCurrentValue[A](obs)
   }
 
 }

--- a/metaserver/src/main/scala/scala/meta/languageserver/PlayJsonEnrichments.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/PlayJsonEnrichments.scala
@@ -1,0 +1,15 @@
+package scala.meta.languageserver
+
+import play.api.libs.json.JsError
+
+object PlayJsonEnrichments {
+  implicit class XtensionPlayJsonError(val jsError: JsError) extends AnyVal {
+    def show: String =
+      jsError.errors.iterator
+        .map {
+          case (path, err) =>
+            s"$path: ${err.mkString(", ")}"
+        }
+        .mkString("; ")
+  }
+}

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
@@ -281,7 +281,6 @@ class ScalametaLanguageServer(
 
   override def hover(
       request: TextDocumentHoverRequest
-<<<<<<< HEAD
   ): Task[Hover] = Task {
     HoverProvider.hover(
       symbolIndex,
@@ -289,17 +288,6 @@ class ScalametaLanguageServer(
       request.params.position.line,
       request.params.position.character
     )
-=======
-  ): Task[Hover] = withPC {
-    scalacProvider.getCompiler(request.params.textDocument) match {
-      case Some(g) =>
-        HoverProvider.hover(
-          g,
-          toPoint(request.params.textDocument, request.params.position)
-        )
-      case None => HoverProvider.empty
-    }
->>>>>>> Re-make ScalacProvider a class
   }
 
   override def references(
@@ -353,7 +341,7 @@ class ScalametaLanguageServer(
           )
         case ResetPresentationCompiler =>
           logger.info("Resetting all compiler instances")
-          scalac.resetCompilers()
+          scalacProvider.resetCompilers()
         case ScalafixUnusedImports =>
           logger.info("Removing unused imports")
           val result =

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
@@ -98,10 +98,15 @@ class ScalametaLanguageServer(
   val (configurationSubscriber, configurationPublisher) =
     ScalametaLanguageServer.configurationStream(connection)
   val buffers: Buffers = Buffers()
-  val symbolIndex: SymbolIndex = SymbolIndex(cwd, connection, buffers, configurationPublisher)
-  val scalacErrorReporter: ScalacErrorReporter = new ScalacErrorReporter(connection)
-  val documentFormattingProvider = new DocumentFormattingProvider(configurationPublisher, cwd)
-  val squiggliesProvider = new SquiggliesProvider(configurationPublisher, cwd, stdout)
+  val symbolIndex: SymbolIndex =
+    SymbolIndex(cwd, connection, buffers, configurationPublisher)
+  val scalacErrorReporter: ScalacErrorReporter = new ScalacErrorReporter(
+    connection
+  )
+  val documentFormattingProvider =
+    new DocumentFormattingProvider(configurationPublisher, cwd)
+  val squiggliesProvider =
+    new SquiggliesProvider(configurationPublisher, cwd, stdout)
   val scalacProvider = new ScalacProvider
   val interactiveSemanticdbs: Observable[semanticdb.Database] =
     sourceChangePublisher
@@ -432,7 +437,7 @@ object ScalametaLanguageServer extends LazyLogging {
   }
 
   def configurationStream(connection: Connection)(
-    implicit scheduler: Scheduler
+      implicit scheduler: Scheduler
   ): (Observer.Sync[JsValue], Observable[Configuration]) = {
     val (subscriber, publisher) = multicast[JsValue]
     val configurationPublisher = publisher

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaLanguageServer.scala
@@ -1,6 +1,5 @@
 package scala.meta.languageserver
 
-import java.io.File
 import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream

--- a/metaserver/src/main/scala/scala/meta/languageserver/Semanticdbs.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Semanticdbs.scala
@@ -18,12 +18,9 @@ import org.langmeta.io.AbsolutePath
 
 object Semanticdbs extends LazyLogging {
 
-  def toSemanticdb(
-      input: Input.VirtualFile,
-      scalac: ScalacProvider
-  ): Option[semanticdb.Database] =
+  def toSemanticdb(input: Input.VirtualFile): Option[semanticdb.Database] =
     for {
-      compiler <- scalac.getCompiler(input)
+      compiler <- ScalacProvider.getCompiler(input)
     } yield toSemanticdb(input, compiler)
 
   def toSemanticdb(

--- a/metaserver/src/main/scala/scala/meta/languageserver/Semanticdbs.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Semanticdbs.scala
@@ -18,7 +18,10 @@ import org.langmeta.io.AbsolutePath
 
 object Semanticdbs extends LazyLogging {
 
-  def toSemanticdb(input: Input.VirtualFile, scalacProvider: ScalacProvider): Option[semanticdb.Database] =
+  def toSemanticdb(
+      input: Input.VirtualFile,
+      scalacProvider: ScalacProvider
+  ): Option[semanticdb.Database] =
     for {
       compiler <- scalacProvider.getCompiler(input)
     } yield toSemanticdb(input, compiler)

--- a/metaserver/src/main/scala/scala/meta/languageserver/Semanticdbs.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Semanticdbs.scala
@@ -18,9 +18,9 @@ import org.langmeta.io.AbsolutePath
 
 object Semanticdbs extends LazyLogging {
 
-  def toSemanticdb(input: Input.VirtualFile): Option[semanticdb.Database] =
+  def toSemanticdb(input: Input.VirtualFile, scalacProvider: ScalacProvider): Option[semanticdb.Database] =
     for {
-      compiler <- ScalacProvider.getCompiler(input)
+      compiler <- scalacProvider.getCompiler(input)
     } yield toSemanticdb(input, compiler)
 
   def toSemanticdb(

--- a/metaserver/src/main/scala/scala/meta/languageserver/compiler/ScalacProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/compiler/ScalacProvider.scala
@@ -2,7 +2,6 @@ package scala.meta.languageserver.compiler
 
 import scala.collection.mutable
 import scala.meta.languageserver.Effects
-import scala.meta.languageserver.ServerConfig
 import scala.meta.languageserver.Uri
 import scala.reflect.io
 import scala.tools.nsc.Settings
@@ -16,9 +15,7 @@ import org.langmeta.inputs.Input
 import org.langmeta.io.AbsolutePath
 
 /** Responsible for keeping fresh scalac global instances. */
-class ScalacProvider(
-    serverConfig: ServerConfig
-) extends LazyLogging {
+object ScalacProvider extends LazyLogging {
 
   def getCompiler(input: Input.VirtualFile): Option[Global] =
     getCompiler(Uri(input.path))
@@ -74,9 +71,6 @@ class ScalacProvider(
     compilerByConfigOrigin.values.foreach {
       case (_, global) => global.askReset()
     }
-}
-
-object ScalacProvider extends LazyLogging {
 
   def addCompilationUnit(
       global: Global,

--- a/metaserver/src/main/scala/scala/meta/languageserver/compiler/ScalacProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/compiler/ScalacProvider.scala
@@ -15,7 +15,7 @@ import org.langmeta.inputs.Input
 import org.langmeta.io.AbsolutePath
 
 /** Responsible for keeping fresh scalac global instances. */
-object ScalacProvider extends LazyLogging {
+class ScalacProvider() extends LazyLogging {
 
   def getCompiler(input: Input.VirtualFile): Option[Global] =
     getCompiler(Uri(input.path))
@@ -71,6 +71,10 @@ object ScalacProvider extends LazyLogging {
     compilerByConfigOrigin.values.foreach {
       case (_, global) => global.askReset()
     }
+
+}
+
+object ScalacProvider {
 
   def addCompilationUnit(
       global: Global,

--- a/metaserver/src/main/scala/scala/meta/languageserver/providers/DocumentFormattingProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/providers/DocumentFormattingProvider.scala
@@ -28,21 +28,20 @@ class DocumentFormattingProvider(configuration: Observable[Configuration], cwd: 
 
   def format(
       input: Input.VirtualFile
-  ): Task[DocumentFormattingResult] = for {
-    formatter <- formatterFromConfiguration
-    config <- scalafmtConfigFromConfiguration
-  } yield {
-    val fullDocumentRange = Range(
-      start = Position(0, 0),
-      end = Position(Int.MaxValue, Int.MaxValue)
-    )
-    val edits = if (Files.isRegularFile(config.toNIO)) {
-      val formattedContent = scalafmt.format(input.value, input.path, config)
-      List(TextEdit(fullDocumentRange, formattedContent))
-    } else {
-      Nil
+  ): Task[DocumentFormattingResult] =
+    formatterFromConfiguration.zip(scalafmtConfigFromConfiguration).map {
+      case (formatter, config) =>
+        val fullDocumentRange = Range(
+          start = Position(0, 0),
+          end = Position(Int.MaxValue, Int.MaxValue)
+        )
+        val edits = if (Files.isRegularFile(config.toNIO)) {
+          val formattedContent = scalafmt.format(input.value, input.path, config)
+          List(TextEdit(fullDocumentRange, formattedContent))
+        } else {
+          Nil
+        }
+        DocumentFormattingResult(edits)
     }
-    DocumentFormattingResult(edits)
-  }
 
 }

--- a/metaserver/src/main/scala/scala/meta/languageserver/providers/DocumentFormattingProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/providers/DocumentFormattingProvider.scala
@@ -47,7 +47,7 @@ class DocumentFormattingProvider(
       .focus(_.scalafmt.confPath)
       .map[Either[String, Option[AbsolutePath]]] {
         case None =>
-          val default = cwd.resolve(Scalafmt.DefaultConf)
+          val default = cwd.resolve(Scalafmt.defaultConfPath)
           if (Files.isRegularFile(default.toNIO)) Right(Some(default))
           else Right(None)
         case Some(relpath) =>

--- a/metaserver/src/main/scala/scala/meta/languageserver/providers/DocumentFormattingProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/providers/DocumentFormattingProvider.scala
@@ -18,7 +18,7 @@ class DocumentFormattingProvider(configuration: Observable[Configuration], cwd: 
   private lazy val scalafmt = Formatter.classloadScalafmt("1.3.0")
 
   private def formatterFromConfiguration: Task[Formatter] = configuration.lastL.map { conf =>
-    if (conf.scalafmt.enable) scalafmt
+    if (conf.scalafmt.enabled) scalafmt
     else Formatter.noop
   }
 

--- a/metaserver/src/main/scala/scala/meta/languageserver/providers/DocumentFormattingProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/providers/DocumentFormattingProvider.scala
@@ -21,13 +21,13 @@ class DocumentFormattingProvider(
   private lazy val scalafmt = Formatter.classloadScalafmt("1.3.0")
 
   private def formatterFromConfiguration: Task[Formatter] =
-    configuration.lastL.map { conf =>
+    configuration.take(1).lastL.map { conf =>
       if (conf.scalafmt.enabled) scalafmt
       else Formatter.noop
     }
 
   private def scalafmtConfigFromConfiguration: Task[AbsolutePath] =
-    configuration.lastL.map { conf =>
+    configuration.take(1).lastL.map { conf =>
       cwd.resolve(conf.scalafmt.confPath)
     }
 

--- a/metaserver/src/main/scala/scala/meta/languageserver/providers/DocumentFormattingProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/providers/DocumentFormattingProvider.scala
@@ -2,6 +2,7 @@ package scala.meta.languageserver.providers
 
 import java.nio.file.Files
 import scala.meta.languageserver.Formatter
+import scala.meta.languageserver.Configuration
 import com.typesafe.scalalogging.LazyLogging
 import langserver.messages.DocumentFormattingResult
 import langserver.types.Position
@@ -9,18 +10,32 @@ import langserver.types.Range
 import langserver.types.TextEdit
 import org.langmeta.inputs.Input
 import org.langmeta.io.AbsolutePath
+import monix.reactive.Observable
+import monix.eval.Task
 
-object DocumentFormattingProvider extends LazyLogging {
+class DocumentFormattingProvider(configuration: Observable[Configuration], cwd: AbsolutePath) extends LazyLogging {
+
+  private lazy val scalafmt = Formatter.classloadScalafmt("1.3.0")
+
+  private def formatterFromConfiguration: Task[Formatter] = configuration.lastL.map { conf =>
+    if (conf.scalafmt.enable) scalafmt
+    else Formatter.noop
+  }
+
+  private def scalafmtConfigFromConfiguration: Task[AbsolutePath] = configuration.lastL.map { conf =>
+    cwd.resolve(conf.scalafmt.confPath)
+  }
+
   def format(
-      input: Input.VirtualFile,
-      scalafmt: Formatter,
-      cwd: AbsolutePath
-  ): DocumentFormattingResult = {
+      input: Input.VirtualFile
+  ): Task[DocumentFormattingResult] = for {
+    formatter <- formatterFromConfiguration
+    config <- scalafmtConfigFromConfiguration
+  } yield {
     val fullDocumentRange = Range(
       start = Position(0, 0),
       end = Position(Int.MaxValue, Int.MaxValue)
     )
-    val config = cwd.resolve(".scalafmt.conf")
     val edits = if (Files.isRegularFile(config.toNIO)) {
       val formattedContent = scalafmt.format(input.value, input.path, config)
       List(TextEdit(fullDocumentRange, formattedContent))
@@ -29,4 +44,5 @@ object DocumentFormattingProvider extends LazyLogging {
     }
     DocumentFormattingResult(edits)
   }
+
 }

--- a/metaserver/src/main/scala/scala/meta/languageserver/providers/DocumentFormattingProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/providers/DocumentFormattingProvider.scala
@@ -13,18 +13,23 @@ import org.langmeta.io.AbsolutePath
 import monix.reactive.Observable
 import monix.eval.Task
 
-class DocumentFormattingProvider(configuration: Observable[Configuration], cwd: AbsolutePath) extends LazyLogging {
+class DocumentFormattingProvider(
+    configuration: Observable[Configuration],
+    cwd: AbsolutePath
+) extends LazyLogging {
 
   private lazy val scalafmt = Formatter.classloadScalafmt("1.3.0")
 
-  private def formatterFromConfiguration: Task[Formatter] = configuration.lastL.map { conf =>
-    if (conf.scalafmt.enabled) scalafmt
-    else Formatter.noop
-  }
+  private def formatterFromConfiguration: Task[Formatter] =
+    configuration.lastL.map { conf =>
+      if (conf.scalafmt.enabled) scalafmt
+      else Formatter.noop
+    }
 
-  private def scalafmtConfigFromConfiguration: Task[AbsolutePath] = configuration.lastL.map { conf =>
-    cwd.resolve(conf.scalafmt.confPath)
-  }
+  private def scalafmtConfigFromConfiguration: Task[AbsolutePath] =
+    configuration.lastL.map { conf =>
+      cwd.resolve(conf.scalafmt.confPath)
+    }
 
   def format(
       input: Input.VirtualFile
@@ -36,7 +41,8 @@ class DocumentFormattingProvider(configuration: Observable[Configuration], cwd: 
           end = Position(Int.MaxValue, Int.MaxValue)
         )
         val edits = if (Files.isRegularFile(config.toNIO)) {
-          val formattedContent = scalafmt.format(input.value, input.path, config)
+          val formattedContent =
+            scalafmt.format(input.value, input.path, config)
           List(TextEdit(fullDocumentRange, formattedContent))
         } else {
           Nil

--- a/metaserver/src/main/scala/scala/meta/languageserver/providers/DocumentFormattingProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/providers/DocumentFormattingProvider.scala
@@ -1,52 +1,91 @@
 package scala.meta.languageserver.providers
 
 import java.nio.file.Files
-import scala.meta.languageserver.Formatter
 import scala.meta.languageserver.Configuration
+import scala.meta.languageserver.Configuration.Scalafmt
+import scala.meta.languageserver.Formatter
+import scala.meta.languageserver.MonixEnrichments._
+import scala.util.control.NonFatal
 import com.typesafe.scalalogging.LazyLogging
+import langserver.core.Notifications
 import langserver.messages.DocumentFormattingResult
+import langserver.types.MessageType
 import langserver.types.Position
 import langserver.types.Range
 import langserver.types.TextEdit
+import monix.eval.Task
+import monix.execution.Scheduler
+import monix.reactive.Observable
 import org.langmeta.inputs.Input
 import org.langmeta.io.AbsolutePath
-import monix.eval.Task
 
 class DocumentFormattingProvider(
-    configuration: Task[Configuration],
-    cwd: AbsolutePath
-) extends LazyLogging {
+    configuration: Observable[Configuration],
+    cwd: AbsolutePath,
+    notifications: Notifications
+)(implicit s: Scheduler)
+    extends LazyLogging {
 
-  private lazy val scalafmt = Formatter.classloadScalafmt("1.3.0")
+  private val formatter: () => Either[String, Formatter] =
+    configuration
+      .focus(_.scalafmt.version)
+      .map[Either[String, Formatter]] { version =>
+        try {
+          // TODO(olafur) convert Jars.fetch to use monix.Task to avoid blocking
+          Right(Formatter.classloadScalafmt(version))
+        } catch {
+          case NonFatal(e) =>
+            val msg =
+              s"Unable to install scalafmt version $version, cause: ${e.getMessage}"
+            Left(msg)
+        }
+      }
+      .toFunction0()
 
-  private def formatterFromConfiguration: Task[Formatter] =
-    configuration.map { conf =>
-      if (conf.scalafmt.enabled) scalafmt
-      else Formatter.noop
-    }
+  private val config: () => Either[String, Option[AbsolutePath]] =
+    configuration
+      .focus(_.scalafmt.confPath)
+      .map[Either[String, Option[AbsolutePath]]] {
+        case None =>
+          val default = cwd.resolve(Scalafmt.DefaultConf)
+          if (Files.isRegularFile(default.toNIO)) Right(Some(default))
+          else Right(None)
+        case Some(relpath) =>
+          val custom = cwd.resolve(relpath)
+          if (Files.isRegularFile(custom.toNIO)) Right(Some(custom))
+          else {
+            Left(s"scalameta.scalafmt.confPath=$relpath is not a file")
+          }
+      }
+      .toFunction0()
 
-  private def scalafmtConfigFromConfiguration: Task[AbsolutePath] =
-    configuration.map { conf =>
-      cwd.resolve(conf.scalafmt.confPath)
-    }
+  private val fullDocumentRange = Range(
+    start = Position(0, 0),
+    end = Position(Int.MaxValue, Int.MaxValue)
+  )
+
+  private def formatted(newText: String) =
+    List(TextEdit(fullDocumentRange, newText))
 
   def format(
       input: Input.VirtualFile
-  ): Task[DocumentFormattingResult] =
-    formatterFromConfiguration.zip(scalafmtConfigFromConfiguration).map {
-      case (formatter, config) =>
-        val fullDocumentRange = Range(
-          start = Position(0, 0),
-          end = Position(Int.MaxValue, Int.MaxValue)
-        )
-        val edits = if (Files.isRegularFile(config.toNIO)) {
-          val formattedContent =
-            formatter.format(input.value, input.path, config)
-          List(TextEdit(fullDocumentRange, formattedContent))
-        } else {
-          Nil
+  ): Task[DocumentFormattingResult] = Task.eval {
+    val edits: List[TextEdit] = formatter() match {
+      case Left(error) =>
+        notifications.showMessage(MessageType.Error, error)
+        Nil
+      case Right(scalafmt) =>
+        config() match {
+          case Left(error) =>
+            notifications.showMessage(MessageType.Error, error)
+            Nil
+          case Right(None) => // default config
+            formatted(scalafmt.format(input.value, input.path))
+          case Right(Some(path)) =>
+            formatted(scalafmt.format(input.value, input.path, path))
         }
-        DocumentFormattingResult(edits)
     }
+    DocumentFormattingResult(edits)
+  }
 
 }

--- a/metaserver/src/main/scala/scala/meta/languageserver/providers/DocumentFormattingProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/providers/DocumentFormattingProvider.scala
@@ -10,24 +10,23 @@ import langserver.types.Range
 import langserver.types.TextEdit
 import org.langmeta.inputs.Input
 import org.langmeta.io.AbsolutePath
-import monix.reactive.Observable
 import monix.eval.Task
 
 class DocumentFormattingProvider(
-    configuration: Observable[Configuration],
+    configuration: Task[Configuration],
     cwd: AbsolutePath
 ) extends LazyLogging {
 
   private lazy val scalafmt = Formatter.classloadScalafmt("1.3.0")
 
   private def formatterFromConfiguration: Task[Formatter] =
-    configuration.take(1).lastL.map { conf =>
+    configuration.map { conf =>
       if (conf.scalafmt.enabled) scalafmt
       else Formatter.noop
     }
 
   private def scalafmtConfigFromConfiguration: Task[AbsolutePath] =
-    configuration.take(1).lastL.map { conf =>
+    configuration.map { conf =>
       cwd.resolve(conf.scalafmt.confPath)
     }
 
@@ -42,7 +41,7 @@ class DocumentFormattingProvider(
         )
         val edits = if (Files.isRegularFile(config.toNIO)) {
           val formattedContent =
-            scalafmt.format(input.value, input.path, config)
+            formatter.format(input.value, input.path, config)
           List(TextEdit(fullDocumentRange, formattedContent))
         } else {
           Nil

--- a/metaserver/src/main/scala/scala/meta/languageserver/providers/SquiggliesProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/providers/SquiggliesProvider.scala
@@ -6,31 +6,35 @@ import com.typesafe.scalalogging.LazyLogging
 import scala.{meta => m}
 import langserver.messages.PublishDiagnostics
 import scala.meta.languageserver.ScalametaEnrichments._
+import scala.meta.languageserver.MonixEnrichments._
 import scala.tools.nsc.interpreter.OutputStream
 import monix.eval.Task
+import monix.execution.Scheduler
+import monix.reactive.Observable
 import org.langmeta.AbsolutePath
 
 class SquiggliesProvider(
-    configuration: Task[Configuration],
+    configuration: Observable[Configuration],
     cwd: AbsolutePath,
     stdout: OutputStream
-) extends LazyLogging {
+)(implicit s: Scheduler)
+    extends LazyLogging {
+  private val isEnabled: () => Boolean =
+    configuration.map(_.scalafix.enabled).toFunction0()
 
   lazy val linter = new Linter(cwd, stdout)
 
   def squigglies(doc: m.Document): Task[Seq[PublishDiagnostics]] =
     squigglies(m.Database(doc :: Nil))
-  def squigglies(db: m.Database): Task[Seq[PublishDiagnostics]] =
-    for {
-      config <- configuration
-    } yield {
+  def squigglies(db: m.Database): Task[Seq[PublishDiagnostics]] = Task.eval {
+    if (!isEnabled()) Nil
+    else {
       db.documents.map { document =>
         val uri = document.input.syntax
         val compilerErrors = document.messages.map(_.toLSP)
-        val scalafixErrors =
-          if (config.scalafix.enabled) linter.linterMessages(document)
-          else Nil
+        val scalafixErrors = linter.linterMessages(document)
         PublishDiagnostics(uri, compilerErrors ++ scalafixErrors)
       }
     }
+  }
 }

--- a/metaserver/src/main/scala/scala/meta/languageserver/providers/SquiggliesProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/providers/SquiggliesProvider.scala
@@ -8,11 +8,10 @@ import langserver.messages.PublishDiagnostics
 import scala.meta.languageserver.ScalametaEnrichments._
 import scala.tools.nsc.interpreter.OutputStream
 import monix.eval.Task
-import monix.reactive.Observable
 import org.langmeta.AbsolutePath
 
 class SquiggliesProvider(
-    configuration: Observable[Configuration],
+    configuration: Task[Configuration],
     cwd: AbsolutePath,
     stdout: OutputStream
 ) extends LazyLogging {
@@ -23,7 +22,7 @@ class SquiggliesProvider(
     squigglies(m.Database(doc :: Nil))
   def squigglies(db: m.Database): Task[Seq[PublishDiagnostics]] =
     for {
-      config <- configuration.take(1).lastL
+      config <- configuration
     } yield {
       db.documents.map { document =>
         val uri = document.input.syntax

--- a/metaserver/src/main/scala/scala/meta/languageserver/providers/SquiggliesProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/providers/SquiggliesProvider.scala
@@ -1,21 +1,32 @@
 package scala.meta.languageserver.providers
 
 import scala.meta.languageserver.Linter
+import scala.meta.languageserver.Configuration
 import com.typesafe.scalalogging.LazyLogging
 import scala.{meta => m}
 import langserver.messages.PublishDiagnostics
 import scala.meta.languageserver.ScalametaEnrichments._
+import scala.tools.nsc.interpreter.OutputStream
+import monix.eval.Task
+import monix.reactive.Observable
+import org.langmeta.AbsolutePath
 
-object SquiggliesProvider extends LazyLogging {
-  def squigglies(doc: m.Document, linter: Linter): Seq[PublishDiagnostics] =
-    squigglies(m.Database(doc :: Nil), linter)
-  def squigglies(db: m.Database, linter: Linter): Seq[PublishDiagnostics] = {
+class SquiggliesProvider(configuration: Observable[Configuration], cwd: AbsolutePath, stdout: OutputStream) extends LazyLogging {
+
+  lazy val linter = new Linter(cwd, stdout)
+
+  def squigglies(doc: m.Document): Task[Seq[PublishDiagnostics]] =
+    squigglies(m.Database(doc :: Nil))
+  def squigglies(db: m.Database): Task[Seq[PublishDiagnostics]] = for {
+    config <- configuration.lastL
+  } yield {
     db.documents.map { document =>
       val uri = document.input.syntax
       val compilerErrors = document.messages.map(_.toLSP)
-      val scalafixErrors = linter.linterMessages(document)
-      val publish = PublishDiagnostics(uri, compilerErrors ++ scalafixErrors)
-      publish
+      val scalafixErrors =
+        if (config.scalafix.enable) linter.linterMessages(document)
+        else Nil
+      PublishDiagnostics(uri, compilerErrors ++ scalafixErrors)
     }
   }
 }

--- a/metaserver/src/main/scala/scala/meta/languageserver/providers/SquiggliesProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/providers/SquiggliesProvider.scala
@@ -23,7 +23,7 @@ class SquiggliesProvider(
     squigglies(m.Database(doc :: Nil))
   def squigglies(db: m.Database): Task[Seq[PublishDiagnostics]] =
     for {
-      config <- configuration.lastL
+      config <- configuration.take(1).lastL
     } yield {
       db.documents.map { document =>
         val uri = document.input.syntax

--- a/metaserver/src/main/scala/scala/meta/languageserver/providers/SquiggliesProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/providers/SquiggliesProvider.scala
@@ -24,7 +24,7 @@ class SquiggliesProvider(configuration: Observable[Configuration], cwd: Absolute
       val uri = document.input.syntax
       val compilerErrors = document.messages.map(_.toLSP)
       val scalafixErrors =
-        if (config.scalafix.enable) linter.linterMessages(document)
+        if (config.scalafix.enabled) linter.linterMessages(document)
         else Nil
       PublishDiagnostics(uri, compilerErrors ++ scalafixErrors)
     }

--- a/metaserver/src/main/scala/scala/meta/languageserver/search/InMemorySymbolIndex.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/search/InMemorySymbolIndex.scala
@@ -113,7 +113,7 @@ class InMemorySymbolIndex(
       sourceJars: List[AbsolutePath]
   ): Task[Effects.IndexSourcesClasspath] =
     for {
-      config <- configuration.lastL
+      config <- configuration.take(1).lastL
     } yield {
       if (!config.search.indexClasspath) Effects.IndexSourcesClasspath
       else {

--- a/metaserver/src/main/scala/scala/meta/languageserver/search/InMemorySymbolIndex.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/search/InMemorySymbolIndex.scala
@@ -26,7 +26,6 @@ import org.langmeta.languageserver.InputEnrichments._
 import org.langmeta.semanticdb.SemanticdbEnrichments._
 import org.langmeta.semanticdb.Symbol
 import monix.eval.Task
-import monix.reactive.Observable
 
 class InMemorySymbolIndex(
     val symbolIndexer: SymbolIndexer,
@@ -34,7 +33,7 @@ class InMemorySymbolIndex(
     cwd: AbsolutePath,
     notifications: Notifications,
     buffers: Buffers,
-    configuration: Observable[Configuration],
+    configuration: Task[Configuration],
 ) extends SymbolIndex
     with LazyLogging {
   private val indexedJars: ConcurrentHashMap[AbsolutePath, Unit] =
@@ -113,7 +112,7 @@ class InMemorySymbolIndex(
       sourceJars: List[AbsolutePath]
   ): Task[Effects.IndexSourcesClasspath] =
     for {
-      config <- configuration.take(1).lastL
+      config <- configuration
     } yield {
       if (!config.search.indexClasspath) Effects.IndexSourcesClasspath
       else {

--- a/metaserver/src/main/scala/scala/meta/languageserver/search/InMemorySymbolIndex.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/search/InMemorySymbolIndex.scala
@@ -114,10 +114,10 @@ class InMemorySymbolIndex(
   ): Task[Effects.IndexSourcesClasspath] = for {
     config <- configuration.lastL
   } yield {
-    if (!config.indexing.classpath) Effects.IndexSourcesClasspath
+    if (!config.search.indexClasspath) Effects.IndexSourcesClasspath
     else {
       val sourceJarsWithJDK =
-        if (config.indexing.jdk)
+        if (config.search.indexJDK)
           CompilerConfig.jdkSources.fold(sourceJars)(_ :: sourceJars)
         else sourceJars
       val buf = List.newBuilder[AbsolutePath]

--- a/metaserver/src/main/scala/scala/meta/languageserver/search/SymbolIndex.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/search/SymbolIndex.scala
@@ -12,6 +12,8 @@ import org.langmeta.internal.semanticdb.{schema => s}
 import org.langmeta.io.AbsolutePath
 import org.langmeta.semanticdb.Symbol
 import monix.eval.Task
+import monix.execution.Scheduler
+import monix.reactive.Observable
 
 trait SymbolIndex extends LazyLogging {
 
@@ -65,8 +67,8 @@ object SymbolIndex {
       cwd: AbsolutePath,
       notifications: Notifications,
       buffers: Buffers,
-      configuration: Task[Configuration]
-  ): SymbolIndex = {
+      configuration: Observable[Configuration]
+  )(implicit s: Scheduler): SymbolIndex = {
     val symbolIndexer = new InMemorySymbolIndexer()
     val documentIndex = new InMemoryDocumentIndex()
     new InMemorySymbolIndex(

--- a/metaserver/src/main/scala/scala/meta/languageserver/search/SymbolIndex.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/search/SymbolIndex.scala
@@ -12,7 +12,6 @@ import org.langmeta.internal.semanticdb.{schema => s}
 import org.langmeta.io.AbsolutePath
 import org.langmeta.semanticdb.Symbol
 import monix.eval.Task
-import monix.reactive.Observable
 
 trait SymbolIndex extends LazyLogging {
 
@@ -66,7 +65,7 @@ object SymbolIndex {
       cwd: AbsolutePath,
       notifications: Notifications,
       buffers: Buffers,
-      configuration: Observable[Configuration]
+      configuration: Task[Configuration]
   ): SymbolIndex = {
     val symbolIndexer = new InMemorySymbolIndexer()
     val documentIndex = new InMemoryDocumentIndex()

--- a/metaserver/src/main/scala/scala/meta/languageserver/search/SymbolIndex.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/search/SymbolIndex.scala
@@ -1,8 +1,8 @@
 package scala.meta.languageserver.search
 
 import scala.meta.languageserver.Buffers
+import scala.meta.languageserver.Configuration
 import scala.meta.languageserver.Effects
-import scala.meta.languageserver.ServerConfig
 import scala.meta.languageserver.Uri
 import scala.meta.languageserver.index.SymbolData
 import com.typesafe.scalalogging.LazyLogging
@@ -11,6 +11,8 @@ import langserver.types.SymbolInformation
 import org.langmeta.internal.semanticdb.{schema => s}
 import org.langmeta.io.AbsolutePath
 import org.langmeta.semanticdb.Symbol
+import monix.eval.Task
+import monix.reactive.Observable
 
 trait SymbolIndex extends LazyLogging {
 
@@ -47,7 +49,7 @@ trait SymbolIndex extends LazyLogging {
 
   def indexDependencyClasspath(
       sourceJars: List[AbsolutePath]
-  ): Effects.IndexSourcesClasspath
+  ): Task[Effects.IndexSourcesClasspath]
 
   /** Register this Database to symbol indexer. */
   def indexDatabase(document: s.Database): Effects.IndexSemanticdb
@@ -64,7 +66,7 @@ object SymbolIndex {
       cwd: AbsolutePath,
       notifications: Notifications,
       buffers: Buffers,
-      serverConfig: ServerConfig
+      configuration: Observable[Configuration]
   ): SymbolIndex = {
     val symbolIndexer = new InMemorySymbolIndexer()
     val documentIndex = new InMemoryDocumentIndex()
@@ -74,7 +76,7 @@ object SymbolIndex {
       cwd,
       notifications,
       buffers,
-      serverConfig
+      configuration
     )
   }
 

--- a/metaserver/src/test/scala/tests/compiler/SquiggliesTest.scala
+++ b/metaserver/src/test/scala/tests/compiler/SquiggliesTest.scala
@@ -10,8 +10,8 @@ import scala.meta.languageserver.Linter
 import scala.meta.languageserver.Semanticdbs
 import scala.meta.languageserver.providers.SquiggliesProvider
 import langserver.messages.PublishDiagnostics
-import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
+import monix.reactive.Observable
 import org.langmeta.inputs.Input
 import org.langmeta.io.AbsolutePath
 import org.langmeta.languageserver.InputEnrichments._
@@ -20,7 +20,7 @@ object SquiggliesTest extends CompilerSuite {
   val tmp: Path = Files.createTempDirectory("metaserver")
   val logFile = tmp.resolve("metaserver.log").toFile
   val out = new PrintStream(new FileOutputStream(logFile))
-  val config = Task.now(Configuration())
+  val config = Observable.now(Configuration())
   val squiggliesProvider =
     new SquiggliesProvider(config, AbsolutePath(tmp), out)
   Files.write(

--- a/metaserver/src/test/scala/tests/compiler/SquiggliesTest.scala
+++ b/metaserver/src/test/scala/tests/compiler/SquiggliesTest.scala
@@ -33,8 +33,8 @@ object SquiggliesTest extends CompilerSuite {
     test(name) {
       val input = Input.VirtualFile(name, original)
       val doc = Semanticdbs.toSemanticdb(input, compiler)
-      val PublishDiagnostics(_, diagnostics) :: Nil =
-        squiggliesProvider.squigglies(doc).runSyncMaybe.right.get
+      val Right(PublishDiagnostics(_, diagnostics) :: Nil) =
+        squiggliesProvider.squigglies(doc).runSyncMaybe
       val obtained = diagnostics.map { d =>
         val pos = input.toPosition(d.range)
         pos.formatMessage(d.severity.getOrElse(???).toString, d.message)

--- a/metaserver/src/test/scala/tests/compiler/SquiggliesTest.scala
+++ b/metaserver/src/test/scala/tests/compiler/SquiggliesTest.scala
@@ -21,7 +21,8 @@ object SquiggliesTest extends CompilerSuite {
   val logFile = tmp.resolve("metaserver.log").toFile
   val out = new PrintStream(new FileOutputStream(logFile))
   val config = Observable(Configuration())
-  val squiggliesProvider = new SquiggliesProvider(config, AbsolutePath(tmp), out)
+  val squiggliesProvider =
+    new SquiggliesProvider(config, AbsolutePath(tmp), out)
   Files.write(
     tmp.resolve(".scalafix.conf"),
     """

--- a/metaserver/src/test/scala/tests/compiler/SquiggliesTest.scala
+++ b/metaserver/src/test/scala/tests/compiler/SquiggliesTest.scala
@@ -1,26 +1,26 @@
 package tests.compiler
 
-import java.nio.file.Files
-import java.nio.file.Path
 import java.io.FileOutputStream
 import java.io.PrintStream
-import scala.meta.languageserver.Linter
+import java.nio.file.Files
+import java.nio.file.Path
+import scala.meta.internal.inputs._
 import scala.meta.languageserver.Configuration
+import scala.meta.languageserver.Linter
 import scala.meta.languageserver.Semanticdbs
 import scala.meta.languageserver.providers.SquiggliesProvider
+import langserver.messages.PublishDiagnostics
+import monix.eval.Task
+import monix.execution.Scheduler.Implicits.global
 import org.langmeta.inputs.Input
 import org.langmeta.io.AbsolutePath
-import scala.meta.internal.inputs._
-import langserver.messages.PublishDiagnostics
 import org.langmeta.languageserver.InputEnrichments._
-import monix.reactive.Observable
-import monix.execution.Scheduler.Implicits.global
 
 object SquiggliesTest extends CompilerSuite {
   val tmp: Path = Files.createTempDirectory("metaserver")
   val logFile = tmp.resolve("metaserver.log").toFile
   val out = new PrintStream(new FileOutputStream(logFile))
-  val config = Observable(Configuration())
+  val config = Task.now(Configuration())
   val squiggliesProvider =
     new SquiggliesProvider(config, AbsolutePath(tmp), out)
   Files.write(

--- a/metaserver/src/test/scala/tests/search/BaseIndexTest.scala
+++ b/metaserver/src/test/scala/tests/search/BaseIndexTest.scala
@@ -9,7 +9,8 @@ import scala.meta.languageserver.Uri
 import scala.meta.languageserver.search.SymbolIndex
 import scala.{meta => m}
 import langserver.core.Notifications
-import monix.eval.Task
+import monix.execution.Scheduler.Implicits.global
+import monix.reactive.Observable
 import org.langmeta.internal.io.PathIO
 import org.langmeta.internal.semanticdb._
 import tests.compiler.CompilerSuite
@@ -20,7 +21,7 @@ abstract class BaseIndexTest extends CompilerSuite {
     PathIO.workingDirectory,
     Notifications.empty,
     buffers,
-    Task.now(Configuration())
+    Observable.now(Configuration())
   )
   def indexDocument(document: m.Document): Effects.IndexSemanticdb =
     symbols.indexDatabase(

--- a/metaserver/src/test/scala/tests/search/BaseIndexTest.scala
+++ b/metaserver/src/test/scala/tests/search/BaseIndexTest.scala
@@ -9,7 +9,7 @@ import scala.meta.languageserver.Uri
 import scala.meta.languageserver.search.SymbolIndex
 import scala.{meta => m}
 import langserver.core.Notifications
-import monix.reactive.Observable
+import monix.eval.Task
 import org.langmeta.internal.io.PathIO
 import org.langmeta.internal.semanticdb._
 import tests.compiler.CompilerSuite
@@ -20,7 +20,7 @@ abstract class BaseIndexTest extends CompilerSuite {
     PathIO.workingDirectory,
     Notifications.empty,
     buffers,
-    Observable(Configuration())
+    Task.now(Configuration())
   )
   def indexDocument(document: m.Document): Effects.IndexSemanticdb =
     symbols.indexDatabase(

--- a/metaserver/src/test/scala/tests/search/BaseIndexTest.scala
+++ b/metaserver/src/test/scala/tests/search/BaseIndexTest.scala
@@ -3,12 +3,13 @@ package tests.search
 import scala.meta.interactive.InteractiveSemanticdb
 import scala.meta.internal.inputs._
 import scala.meta.languageserver.Buffers
+import scala.meta.languageserver.Configuration
 import scala.meta.languageserver.Effects
-import scala.meta.languageserver.ServerConfig
 import scala.meta.languageserver.Uri
 import scala.meta.languageserver.search.SymbolIndex
 import scala.{meta => m}
 import langserver.core.Notifications
+import monix.reactive.Observable
 import org.langmeta.internal.io.PathIO
 import org.langmeta.internal.semanticdb._
 import tests.compiler.CompilerSuite
@@ -19,7 +20,7 @@ abstract class BaseIndexTest extends CompilerSuite {
     PathIO.workingDirectory,
     Notifications.empty,
     buffers,
-    ServerConfig(PathIO.workingDirectory)
+    Observable(Configuration())
   )
   def indexDocument(document: m.Document): Effects.IndexSemanticdb =
     symbols.indexDatabase(

--- a/metaserver/src/test/scala/tests/search/SymbolIndexTest.scala
+++ b/metaserver/src/test/scala/tests/search/SymbolIndexTest.scala
@@ -7,7 +7,6 @@ import java.nio.file.Paths
 import scala.meta.languageserver.ScalametaEnrichments._
 import scala.meta.languageserver.internal.BuildInfo
 import scala.meta.languageserver.ScalametaLanguageServer
-import scala.meta.languageserver.ServerConfig
 import scala.meta.languageserver.Uri
 import scala.meta.languageserver.search.InMemorySymbolIndex
 import scala.meta.languageserver.search.InverseSymbolIndexer
@@ -52,18 +51,12 @@ object SymbolIndexTest extends MegaSuite {
     path.UserTest.toString()
   )
   val s = TestScheduler()
-  val config = ServerConfig(
-    cwd,
-    setupScalafmt = false,
-    indexJDK = false, // TODO(olafur) enabling this breaks go to definition
-    indexClasspath = true // set to false to speedup edit/debug cycle
-  )
   val client = new PipedOutputStream()
   val stdin = new PipedInputStream(client)
   val stdout = new PipedOutputStream()
   // TODO(olafur) run this as part of utest.runner.Framework.setup()
   val server =
-    new ScalametaLanguageServer(config, stdin, stdout, System.out)(s)
+    new ScalametaLanguageServer(cwd, stdin, stdout, System.out)(s)
   server.initialize(0L, cwd.toString(), ClientCapabilities()).runAsync(s)
   while (s.tickOne()) () // Trigger indexing
   val index: SymbolIndex = server.symbolIndex

--- a/test-workspace/src/main/scala/example/User.scala
+++ b/test-workspace/src/main/scala/example/User.scala
@@ -1,19 +1,12 @@
 package a
-import java.util.Scanner
 
 case class User(name: String, age: Int)
 
 object a {
-
-  new Scanner(System.in).nextInt()
-  java.nio.file.Paths.get("blah")
-
   val x = "ba"
   val y = List(1, x).length
   def z = {
-    val localSymbol =
-      "222" // can be renamed
-
+    val localSymbol = "222" // can be renamed
     localSymbol.length
   }
 }

--- a/test-workspace/src/main/scala/example/User.scala
+++ b/test-workspace/src/main/scala/example/User.scala
@@ -1,12 +1,19 @@
 package a
+import java.util.Scanner
 
 case class User(name: String, age: Int)
 
 object a {
+
+  new Scanner(System.in).nextInt()
+  java.nio.file.Paths.get("blah")
+
   val x = "ba"
   val y = List(1, x).length
   def z = {
-    val localSymbol = "222" // can be renamed
+    val localSymbol =
+      "222" // can be renamed
+
     localSymbol.length
   }
 }

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -13,10 +13,10 @@
     "configuration": {
       "title": "Scalameta Language Server",
       "properties": {
-        "scalameta.scalafmt.enabled": {
-          "type": "boolean",
-          "default": true,
-          "description": "Enable formatting with Scalafmt"
+        "scalameta.scalafmt.version": {
+          "type": "string",
+          "default": "1.3.0",
+          "description": "Version of scalafmt to use, default to latest stable release."
         },
         "scalameta.scalafmt.confPath": {
           "type": "string",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -13,6 +13,16 @@
     "configuration": {
       "title": "Scalameta Language Server",
       "properties": {
+        "scalameta.scalac.enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "EXPERIMENTAL. Enable squigglies and completions as you type with the Scala Presentation Compiler."
+        },
+        "scalameta.scalafmt.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable formatting with scalafmt"
+        },
         "scalameta.scalafmt.version": {
           "type": "string",
           "default": "1.3.0",
@@ -43,7 +53,7 @@
         "scalameta.search.indexJDK": {
           "type": "boolean",
           "default": false,
-          "description": "Enable indexing of the JDK"
+          "description": "EXPERIMENTAL. Enable indexing of the JDK"
         },
         "scalameta.hover.enabled": {
           "type": "boolean",
@@ -54,11 +64,6 @@
           "type": "boolean",
           "default": true,
           "description": "Enable renaming symbols"
-        },
-        "scalameta.experimental.scalac.enableCompletions": {
-          "type": "boolean",
-          "default": false,
-          "description": "Enable completions as you type"
         }
       }
     },

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -1,74 +1,107 @@
 {
-    "name": "vscode-scalameta",
-    "displayName": "vscode-scalameta",
-    "description": "",
-    "version": "0.0.1",
-    "publisher": "gabro",
-    "engines": {
-        "vscode": "^1.17.0"
-    },
-    "categories": [
-        "Other"
-    ],
-    "activationEvents": [
-        "onLanguage:scala"
-    ],
-    "contributes": {
-        "configuration": {
-            "title": "Scalameta Language Server",
-            "properties": {
-                "scalameta.scalafixConfPath": {
-                    "type": "string",
-                    "default": ".scalafix.conf",
-                    "description": "Path to the Scalafix configuration, relative to the workspace path"
-                },
-                "scalameta.scalafmtConfPath": {
-                    "type": "string",
-                    "default": ".scalafmt.conf",
-                    "description": "Path to the Scalafmt configuration, relative to the workspace path"
-                },
-                "scalameta.enableCompletions": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Enables completions as you type"
-                }
-            }
+  "name": "vscode-scalameta",
+  "displayName": "vscode-scalameta",
+  "description": "",
+  "version": "0.0.1",
+  "publisher": "gabro",
+  "engines": {
+    "vscode": "^1.17.0"
+  },
+  "categories": ["Other"],
+  "activationEvents": ["onLanguage:scala"],
+  "contributes": {
+    "configuration": {
+      "title": "Scalameta Language Server",
+      "properties": {
+        "scalameta.scalafmt.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable formatting with Scalafmt"
         },
-        "commands": [{
-            "command": "scalameta.restartServer",
-            "category": "Scalameta Language Server",
-            "title": "Restart server"
-        }, {
-            "command": "scalameta.clearIndexCache",
-            "category": "Scalameta Language Server",
-            "title": "Clear index cache"
-        }, {
-            "command": "scalameta.resetPresentationCompiler",
-            "category": "Scalameta Language Server",
-            "title": "Reset presentation compilers"
-        }]
+        "scalameta.scalafmt.confPath": {
+          "type": "string",
+          "default": ".scalafmt.conf",
+          "description":
+            "Path to the Scalafmt configuration, relative to the workspace path"
+        },
+        "scalameta.scalafix.enable": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable Scalafix diagnostics"
+        },
+        "scalameta.scalafix.confPath": {
+          "type": "string",
+          "default": ".scalafix.conf",
+          "description":
+            "Path to the Scalafix configuration, relative to the workspace path"
+        },
+        "scalameta.search.indexClasspath": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable indexing of the classpath"
+        },
+        "scalameta.search.indexJDK": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable indexing of the JDK"
+        },
+        "scalameta.hover.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable tooltips on hover"
+        },
+        "scalameta.rename.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable renaming symbols"
+        },
+        "scalameta.experimental.completions.enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable completions as you type"
+        }
+      }
     },
-    "main": "./out/extension",
-    "scripts": {
-        "vscode:prepublish": "npm run download-coursier && npm run compile",
-        "download-coursier": "curl -L -o coursier https://github.com/coursier/coursier/raw/v1.0.0-RC13/coursier",
-        "compile": "tsc -p ./",
-        "watch": "tsc -watch -p ./",
-        "postinstall": "node ./node_modules/vscode/bin/install",
-        "test": "npm run compile && node ./node_modules/vscode/bin/test",
-        "build": "vsce package"
-    },
-    "devDependencies": {
-        "@types/mocha": "^2.2.42",
-        "@types/node": "^7.0.43",
-        "typescript": "^2.5.3",
-        "vsce": "^1.32.0"
-    },
-    "dependencies": {
-        "expand-home-dir": "0.0.3",
-        "find-java-home": "^0.2.0",
-        "path-exists": "^3.0.0",
-        "vscode": "^1.1.5",
-        "vscode-languageclient": "^3.4.5"
-    }
+    "commands": [
+      {
+        "command": "scalameta.restartServer",
+        "category": "Scalameta Language Server",
+        "title": "Restart server"
+      },
+      {
+        "command": "scalameta.clearIndexCache",
+        "category": "Scalameta Language Server",
+        "title": "Clear index cache"
+      },
+      {
+        "command": "scalameta.resetPresentationCompiler",
+        "category": "Scalameta Language Server",
+        "title": "Reset presentation compilers"
+      }
+    ]
+  },
+  "main": "./out/extension",
+  "scripts": {
+    "vscode:prepublish": "npm run download-coursier && npm run compile",
+    "download-coursier":
+      "curl -L -o coursier https://github.com/coursier/coursier/raw/v1.0.0-RC13/coursier",
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "postinstall": "node ./node_modules/vscode/bin/install",
+    "test": "npm run compile && node ./node_modules/vscode/bin/test",
+    "build": "vsce package"
+  },
+  "devDependencies": {
+    "@types/mocha": "^2.2.42",
+    "@types/node": "^7.0.43",
+    "typescript": "^2.5.3",
+    "vsce": "^1.32.0"
+  },
+  "dependencies": {
+    "expand-home-dir": "0.0.3",
+    "find-java-home": "^0.2.0",
+    "path-exists": "^3.0.0",
+    "vscode": "^1.1.5",
+    "vscode-languageclient": "^3.4.5"
+  }
 }

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -24,7 +24,7 @@
           "description":
             "Path to the Scalafmt configuration, relative to the workspace path"
         },
-        "scalameta.scalafix.enable": {
+        "scalameta.scalafix.enabled": {
           "type": "boolean",
           "default": true,
           "description": "Enable Scalafix diagnostics"
@@ -55,7 +55,7 @@
           "default": true,
           "description": "Enable renaming symbols"
         },
-        "scalameta.experimental.completions.enabled": {
+        "scalameta.experimental.scalac.enableCompletions": {
           "type": "boolean",
           "default": false,
           "description": "Enable completions as you type"


### PR DESCRIPTION
This turned out to be a bit larger than I imagined, so I'm opening the PR although it's not completely done.

Some highlights:
- we now produce an `Observable[Configuration]` that gets passed around to providers
- as a result, providers are now in charge of instantiating whatever resource they need, using the configuration (e.g.  `DocumentFormattingProvider` creates a `Formatter`, instead of receiving it as input). I think this makes more sense in term of ownership and the `ScalametaLanguageServer` is now only managing providers, instead of all their dependencies)
- since now most providers' actions require accessing the configuration via `lastL`, they now return a `Task` directly, which again I think it makes sense. _"Task all the things!"_ (cit)
- I've decided to use `lastL` and not `lastOptionL`, which is a bit inconvenient to work with. In order to guarantee that the configuration observable is never empty I've decided to feed it a default configuration upon creation.

Future work (for another PR):
- finish adding features to the configuration
- use the features to dynamically register/unregister server capabilities (instead of determining them statically at boot)

### TODO
- [x] investigate test failures
- [x] add new configuration options to vscode client

