### PR TITLE
Integrate with sbt language server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ jobs:
       script: ./bin/scalafmt --test
     - env: TEST="sbt test"
       script:
-        - sbt *:scalametaEnableCompletions test scalafixTest
+        - sbt startServer *:scalametaEnableCompletions test scalafixTest
     # release only on merge commits or tags
     - stage: release
       script: if [[ "$(git rev-list --merges HEAD^..HEAD)" || "$TRAVIS_TAG" ]]; then sbt releaseEarly; else echo "skipping release"; fi

--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,8 @@ inThisBuild(
       licenses := Seq(
         "Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")
       ),
+      testFrameworks := new TestFramework("utest.runner.Framework") :: Nil,
+      libraryDependencies += "com.lihaoyi" %% "utest" % "0.6.0" % Test,
       homepage := Some(url("https://github.com/scalameta/language-server")),
       developers := List(
         Developer(
@@ -71,6 +73,7 @@ lazy val V = new {
   val enumeratum = "1.5.12"
   val circe = "0.9.0"
   val cats = "1.0.1"
+  val monix = "2.3.0"
 }
 
 lazy val noPublish = List(
@@ -88,6 +91,15 @@ lazy val semanticdbSettings = List(
   ),
   scalacOptions += "-Yrangepos"
 )
+
+lazy val sbtrpc = project
+  .settings(
+    libraryDependencies ++= List(
+      "net.java.dev.jna" % "jna" % "4.1.0",
+      "net.java.dev.jna" % "jna-platform" % "4.1.0"
+    )
+  )
+  .disablePlugins(ScalafixPlugin)
 
 lazy val jsonrpc = project
   .settings(
@@ -117,7 +129,6 @@ lazy val metaserver = project
         flatPackage = true // Don't append filename to package
       ) -> sourceManaged.in(Compile).value./("protobuf")
     ),
-    testFrameworks := new TestFramework("utest.runner.Framework") :: Nil,
     fork in Test := true, // required for jni interrop with leveldb.
     buildInfoKeys := Seq[BuildInfoKey](
       "testWorkspaceBaseDirectory" ->
@@ -125,7 +136,7 @@ lazy val metaserver = project
     ),
     buildInfoPackage := "scala.meta.languageserver.internal",
     libraryDependencies ++= List(
-      "ch.epfl.scala" % "scalafix-cli" % V.scalafix cross CrossVersion.full,
+      "ch.epfl.scala" % "scalafix-reflect" % V.scalafix cross CrossVersion.full,
       "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0", // for edit-distance
       "com.thoughtworks.qdox" % "qdox" % "2.0-M7", // for java mtags
       "io.get-coursier" %% "coursier" % coursier.util.Properties.version, // for jars
@@ -134,13 +145,13 @@ lazy val metaserver = project
       "me.xdrop" % "fuzzywuzzy" % "1.1.9", // for workspace/symbol
       "org.fusesource.leveldbjni" % "leveldbjni-all" % "1.8", // for caching classpath index
       "org.scalameta" %% "semanticdb-scalac" % V.scalameta cross CrossVersion.full,
-      "com.lihaoyi" %% "utest" % "0.6.0" % Test,
       "org.scalameta" %% "testkit" % V.scalameta % Test
     )
   )
   .dependsOn(
     testWorkspace % "test->test",
-    lsp4s
+    lsp4s,
+    sbtrpc
   )
   .enablePlugins(BuildInfoPlugin)
 

--- a/build.sbt
+++ b/build.sbt
@@ -92,15 +92,6 @@ lazy val semanticdbSettings = List(
   scalacOptions += "-Yrangepos"
 )
 
-lazy val sbtrpc = project
-  .settings(
-    libraryDependencies ++= List(
-      "net.java.dev.jna" % "jna" % "4.1.0",
-      "net.java.dev.jna" % "jna-platform" % "4.1.0"
-    )
-  )
-  .disablePlugins(ScalafixPlugin)
-
 lazy val jsonrpc = project
   .settings(
     libraryDependencies ++= List(
@@ -136,7 +127,7 @@ lazy val metaserver = project
     ),
     buildInfoPackage := "scala.meta.languageserver.internal",
     libraryDependencies ++= List(
-      "org.scala-sbt.ipcsocket" % "ipcsocket" % "1.0.0",
+      "org.scala-sbt.ipcsocket" % "ipcsocket" % "1.0.0", // for sbt server
       "ch.epfl.scala" % "scalafix-reflect" % V.scalafix cross CrossVersion.full,
       "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0", // for edit-distance
       "com.thoughtworks.qdox" % "qdox" % "2.0-M7", // for java mtags
@@ -151,8 +142,7 @@ lazy val metaserver = project
   )
   .dependsOn(
     testWorkspace % "test->test",
-    lsp4s,
-    sbtrpc
+    lsp4s
   )
   .enablePlugins(BuildInfoPlugin)
 

--- a/build.sbt
+++ b/build.sbt
@@ -146,6 +146,13 @@ lazy val metaserver = project
   )
   .enablePlugins(BuildInfoPlugin)
 
+lazy val integration = project
+  .in(file("tests/integration"))
+  .settings(
+    noPublish
+  )
+  .dependsOn(metaserver % "compile->compile;test->test")
+
 lazy val testWorkspace = project
   .in(file("test-workspace"))
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -136,6 +136,7 @@ lazy val metaserver = project
     ),
     buildInfoPackage := "scala.meta.languageserver.internal",
     libraryDependencies ++= List(
+      "org.scala-sbt.ipcsocket" % "ipcsocket" % "1.0.0",
       "ch.epfl.scala" % "scalafix-reflect" % V.scalafix cross CrossVersion.full,
       "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0", // for edit-distance
       "com.thoughtworks.qdox" % "qdox" % "2.0-M7", // for java mtags

--- a/jsonrpc/src/main/scala/org/langmeta/jsonrpc/JsonRpcClient.scala
+++ b/jsonrpc/src/main/scala/org/langmeta/jsonrpc/JsonRpcClient.scala
@@ -5,9 +5,16 @@ import io.circe.Encoder
 import monix.eval.Task
 
 trait JsonRpcClient {
+  final def notify[A](endpoint: Endpoint[A, Unit], notification: A): Unit =
+    notify[A](endpoint.method, notification)(endpoint.encoderA)
   def notify[A: Encoder](method: String, notification: A): Unit
   def serverRespond(response: Response): Unit
   def clientRespond(response: Response): Unit
+  final def request[A, B](
+      endpoint: Endpoint[A, B],
+      req: A
+  ): Task[Either[Response.Error, B]] =
+    request[A, B](endpoint.method, req)(endpoint.encoderA, endpoint.decoderB)
   def request[A: Encoder, B: Decoder](
       method: String,
       request: A

--- a/jsonrpc/src/main/scala/org/langmeta/jsonrpc/MessageWriter.scala
+++ b/jsonrpc/src/main/scala/org/langmeta/jsonrpc/MessageWriter.scala
@@ -4,7 +4,6 @@ import java.io.OutputStream
 import java.nio.charset.StandardCharsets
 import com.typesafe.scalalogging.Logger
 import io.circe.Encoder
-import io.circe.Json
 import io.circe.syntax._
 
 /**
@@ -35,9 +34,7 @@ class MessageWriter(out: OutputStream, logger: Logger) {
     lock.synchronized {
       require(h.get(ContentLen).isEmpty)
 
-      val json = msg.asJson.withObject(
-        obj => Json.fromJsonObject(obj.add("jsonrpc", Json.fromString("2.0")))
-      )
+      val json = msg.asJson.withObject(_.add("jsonrpc", "2.0".asJson).asJson)
       val str = json.noSpaces
       val contentBytes = str.getBytes(StandardCharsets.UTF_8)
       val headers = (h + (ContentLen -> contentBytes.length))

--- a/jsonrpc/src/main/scala/org/langmeta/jsonrpc/RequestId.scala
+++ b/jsonrpc/src/main/scala/org/langmeta/jsonrpc/RequestId.scala
@@ -6,8 +6,8 @@ import io.circe.Encoder
 
 sealed trait RequestId
 object RequestId {
-  def apply(n: Int): RequestId.Number =
-    RequestId.Number(Json.fromBigDecimal(BigDecimal(n)))
+  def apply(n: Int): RequestId.String =
+    RequestId.String(Json.fromString(n.toString))
   implicit val decoder: Decoder[RequestId] = Decoder.decodeJson.map {
     case s if s.isString => RequestId.String(s)
     case n if n.isNumber => RequestId.Number(n)

--- a/lsp4s/src/main/scala/org/langmeta/lsp/LanguageClient.scala
+++ b/lsp4s/src/main/scala/org/langmeta/lsp/LanguageClient.scala
@@ -43,19 +43,8 @@ class LanguageClient(out: OutputStream, logger: Logger) extends JsonRpcClient {
         case Response.Error(_, requestId) => Some(requestId)
       }
       callback <- activeServerRequests.get(id).orElse {
-        val fallback = for {
-          string <- id.asJson.asString
-          number <- Try(string.toInt).toOption
-          request <- activeServerRequests.get(RequestId(number))
-        } yield {
-          // seems to be necessary for sbt-server :(
-          logger.info(s"Expected int response id, got string $id")
-          request
-        }
-        fallback.orElse {
-          logger.error(s"Response to unknown request: $response")
-          None
-        }
+        logger.error(s"Response to unknown request: $response")
+        None
       }
     } {
       activeServerRequests.remove(id)

--- a/lsp4s/src/main/scala/org/langmeta/lsp/LanguageClient.scala
+++ b/lsp4s/src/main/scala/org/langmeta/lsp/LanguageClient.scala
@@ -3,7 +3,6 @@ package org.langmeta.lsp
 import java.io.OutputStream
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.duration.Duration
-import scala.util.Try
 import cats.syntax.either._
 import com.typesafe.scalalogging.Logger
 import io.circe.Decoder

--- a/metaserver/src/main/scala/scala/meta/languageserver/Configuration.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Configuration.scala
@@ -11,6 +11,7 @@ import io.circe.generic.extras.{Configuration => CirceConfiguration}
 import Configuration._
 
 @JsonCodec case class Configuration(
+    sbt: Sbt = Sbt(),
     scalac: Scalac = Scalac(),
     scalafmt: Scalafmt = Scalafmt(),
     scalafix: Scalafix = Scalafix(),
@@ -23,6 +24,10 @@ object Configuration {
   implicit val circeConfiguration: CirceConfiguration =
     CirceConfiguration.default.withDefaults
 
+  @JsonCodec case class Sbt(
+      enabled: Boolean = false,
+      command: String = "test:compile"
+  )
   @JsonCodec case class Scalac(enabled: Boolean = false)
   @JsonCodec case class Hover(enabled: Boolean = false)
   @JsonCodec case class Rename(enabled: Boolean = false)

--- a/metaserver/src/main/scala/scala/meta/languageserver/Models.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Models.scala
@@ -1,0 +1,17 @@
+package scala.meta.languageserver
+
+import io.circe.Json
+import io.circe.generic.JsonCodec
+import org.langmeta.io.AbsolutePath
+
+@JsonCodec case class ActiveJson(uri: String)
+
+@JsonCodec case class SbtInitializeParams(
+    initializationOptions: Json = Json.obj()
+)
+@JsonCodec case class SbtInitializeResult(json: Json)
+
+@JsonCodec case class SbtExecParams(commandLine: String)
+
+case class MissingActiveJson(path: AbsolutePath)
+    extends Exception(s"sbt-server 1.1.0 is not running, $path does not exist")

--- a/metaserver/src/main/scala/scala/meta/languageserver/Models.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Models.scala
@@ -6,6 +6,9 @@ import org.langmeta.io.AbsolutePath
 
 @JsonCodec case class ActiveJson(uri: String)
 
+@JsonCodec case class SettingParams(setting: String)
+@JsonCodec case class SettingResult(value: Json, contentType: Json)
+
 @JsonCodec case class SbtInitializeParams(
     initializationOptions: Json = Json.obj()
 )
@@ -15,3 +18,4 @@ import org.langmeta.io.AbsolutePath
 
 case class MissingActiveJson(path: AbsolutePath)
     extends Exception(s"sbt-server 1.1.0 is not running, $path does not exist")
+case class SbtServerConnectionError(msg: String) extends Exception(msg)

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaServices.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaServices.scala
@@ -11,17 +11,22 @@ import scala.concurrent.duration.FiniteDuration
 import scala.meta.languageserver.compiler.CompilerConfig
 import scala.meta.languageserver.compiler.Cursor
 import scala.meta.languageserver.compiler.ScalacProvider
+import org.langmeta.lsp.Window.showMessage
 import org.langmeta.lsp.{
   Lifecycle => lc,
   TextDocument => td,
   Workspace => ws,
   _
 }
+import scala.meta.languageserver.MonixEnrichments._
 import org.langmeta.jsonrpc.Response
 import org.langmeta.jsonrpc.Services
 import scala.meta.languageserver.providers._
 import scala.meta.languageserver.refactoring.OrganizeImports
+import scala.meta.languageserver.sbtserver.Sbt
+import scala.meta.languageserver.sbtserver.SbtServer
 import scala.meta.languageserver.search.SymbolIndex
+import scala.util.control.NonFatal
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.Json
 import io.github.soc.directories.ProjectDirectories
@@ -39,6 +44,7 @@ import org.langmeta.internal.io.PathIO
 import org.langmeta.internal.semanticdb.XtensionDatabase
 import org.langmeta.internal.semanticdb.schema
 import org.langmeta.io.AbsolutePath
+import org.langmeta.jsonrpc.JsonRpcClient
 import org.langmeta.languageserver.InputEnrichments._
 import org.langmeta.lsp.LanguageClient
 import org.langmeta.semanticdb
@@ -50,6 +56,8 @@ class ScalametaServices(
 ) extends LazyLogging {
   implicit val scheduler: Scheduler = s
   implicit val languageClient: LanguageClient = client
+  private var sbtClient: Option[JsonRpcClient] = None
+  private var sbtCancelable: Option[Cancelable] = None
   private val tempSourcesDir: AbsolutePath =
     cwd.resolve("target").resolve("sources")
   // Always run the presentation compiler on the same thread
@@ -114,6 +122,20 @@ class ScalametaServices(
     }
   val scalacErrors: Observable[Effects.PublishScalacDiagnostics] =
     metaSemanticdbs.map(scalacErrorReporter.reportErrors)
+  val sbtServerEnabled: () => Boolean =
+    configurationPublisher
+      .focus(_.sbt.enabled)
+      .doOnNext {
+        case true =>
+          connectToSbtServer()
+        case false =>
+          sbtClient = None
+          sbtCancelable.foreach(_.cancel())
+          sbtCancelable = None
+      }
+      .toFunction0()
+  val latestConfig: () => Configuration =
+    configurationPublisher.toFunction0()
   private var cancelEffects = List.empty[Cancelable]
   val effects: List[Observable[Effects]] = List(
     configurationPublisher.map(_ => Effects.UpdateBuffers),
@@ -131,6 +153,7 @@ class ScalametaServices(
     LSPLogger.notifications = Some(client)
     cancelEffects = effects.map(_.subscribe())
     loadAllRelevantFilesInThisWorkspace()
+    val commands = WorkspaceCommand.values.map(_.entryName)
     val capabilities = ServerCapabilities(
       completionProvider = Some(
         CompletionOptions(
@@ -149,8 +172,7 @@ class ScalametaServices(
       documentSymbolProvider = true,
       documentFormattingProvider = true,
       hoverProvider = true,
-      executeCommandProvider =
-        ExecuteCommandOptions(WorkspaceCommand.values.map(_.entryName)),
+      executeCommandProvider = ExecuteCommandOptions(commands),
       workspaceSymbolProvider = true,
       renameProvider = true,
       codeActionProvider = true
@@ -226,12 +248,14 @@ class ScalametaServices(
       ()
     }
     .notification(td.didSave) { _ =>
-      ()
+      if (sbtServerEnabled()) {
+        sbtCompile()
+      }
     }
     .notification(ws.didChangeConfiguration) { params =>
       params.settings.hcursor.downField("scalameta").as[Configuration] match {
         case Left(err) =>
-          Window.showMessage.notify(
+          showMessage.notify(
             ShowMessageParams(MessageType.Error, err.toString)
           )
         case Right(conf) =>
@@ -367,6 +391,49 @@ class ScalametaServices(
         applied.right.map(_ => Json.Null)
       }
       response
+    case SbtConnect =>
+      Task {
+        if (!sbtServerEnabled()) {
+          showMessage.error("Set scalameta.sbt.enabled=true to use sbt server.")
+        } else {
+          connectToSbtServer()
+        }
+        Right(Json.Null)
+      }
+  }
+
+  private def sbtCompile(): Unit = sbtClient match {
+    case None => ()
+    case Some(sbt) =>
+      // TODO(olafur) support running other commands than "compile"
+      // running top-level "compile" is sub-optimal for large builds
+      // especially cross-built builds with scala.js/native
+      Sbt
+        .exec(latestConfig().sbt.command)(sbt, s)
+        .onErrorRecover {
+          case NonFatal(err) =>
+            // TODO(olafur) figure out why this "broken pipe" is not getting
+            // caught here.
+            logger.error("Failed to send sbt compile", err)
+            showMessage.warn(
+              "Lost connection to sbt server. " +
+                "Restart the sbt session and run the 'Re-connect to sbt server' command"
+            )
+        }
+        .runAsync
+  }
+
+  private def connectToSbtServer(): Unit = {
+    sbtCancelable.foreach(_.cancel())
+    new SbtServer(cwd, client).connect.foreach {
+      case Left(err) => showMessage.error(err)
+      case Right((newSbtClient, cancel)) =>
+        logger.info("Established connection with sbt server 😎")
+        sbtClient = Some(newSbtClient)
+        sbtCancelable = Some(cancel)
+        cancelEffects ::= cancel
+        sbtCompile() // run compile right away.
+    }
   }
 
   private def toCursor(

--- a/metaserver/src/main/scala/scala/meta/languageserver/WorkspaceCommand.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/WorkspaceCommand.scala
@@ -11,6 +11,7 @@ case object WorkspaceCommand extends Enum[WorkspaceCommand] {
   case object ClearIndexCache extends WorkspaceCommand
   case object ResetPresentationCompiler extends WorkspaceCommand
   case object ScalafixUnusedImports extends WorkspaceCommand
+  case object SbtConnect extends WorkspaceCommand
 
   val values = findValues
 

--- a/metaserver/src/main/scala/scala/meta/languageserver/sbtserver/Sbt.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/sbtserver/Sbt.scala
@@ -3,14 +3,24 @@ package scala.meta.languageserver.sbtserver
 import scala.meta.languageserver.SbtExecParams
 import scala.meta.languageserver.SbtInitializeParams
 import scala.meta.languageserver.SbtInitializeResult
+import scala.meta.languageserver.SettingParams
+import scala.meta.languageserver.SettingResult
 import monix.eval.Task
 import monix.execution.Scheduler
 import org.langmeta.jsonrpc.Endpoint
 import org.langmeta.jsonrpc.JsonRpcClient
+import org.langmeta.jsonrpc.Response
 
 trait Sbt {
   object initialize
       extends Endpoint[SbtInitializeParams, SbtInitializeResult]("initialize")
+  object setting extends Endpoint[SettingParams, SettingResult]("sbt/setting") {
+    def query(setting: String)(
+        implicit client: JsonRpcClient
+    ): Task[Either[Response.Error, SettingResult]] =
+      super.request(SettingParams(setting))
+
+  }
   object exec extends Endpoint[SbtExecParams, Unit]("sbt/exec") {
     def apply(
         commandLine: String

--- a/metaserver/src/main/scala/scala/meta/languageserver/sbtserver/Sbt.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/sbtserver/Sbt.scala
@@ -1,0 +1,24 @@
+package scala.meta.languageserver.sbtserver
+
+import scala.meta.languageserver.SbtExecParams
+import scala.meta.languageserver.SbtInitializeParams
+import scala.meta.languageserver.SbtInitializeResult
+import monix.eval.Task
+import monix.execution.Scheduler
+import org.langmeta.jsonrpc.Endpoint
+import org.langmeta.jsonrpc.JsonRpcClient
+
+trait Sbt {
+  object initialize
+      extends Endpoint[SbtInitializeParams, SbtInitializeResult]("initialize")
+  object exec extends Endpoint[SbtExecParams, Unit]("sbt/exec") {
+    def apply(
+        commandLine: String
+    )(implicit client: JsonRpcClient, s: Scheduler): Task[Unit] = {
+      // NOTE(olafur) sbt/exec is a request that never responds
+      super.request(SbtExecParams(commandLine)).map(_ => Unit)
+    }
+  }
+}
+
+object Sbt extends Sbt

--- a/metaserver/src/main/scala/scala/meta/languageserver/sbtserver/SbtServer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/sbtserver/SbtServer.scala
@@ -78,7 +78,8 @@ object SbtServer extends LazyLogging {
           new LanguageClient(socket.getOutputStream, logger)
         val messages =
           BaseProtocolMessage.fromInputStream(socket.getInputStream)
-        val server = new LanguageServer(messages, client, services, scheduler)
+        val server =
+          new LanguageServer(messages, client, services, scheduler, logger)
         val runningServer =
           server.startTask.doOnCancel(Task.eval(socket.close())).runAsync
         val initialize = client.request(Sbt.initialize, SbtInitializeParams())

--- a/metaserver/src/main/scala/scala/meta/languageserver/sbtserver/SbtServer.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/sbtserver/SbtServer.scala
@@ -1,0 +1,92 @@
+package scala.meta.languageserver.sbtserver
+
+import java.io.IOException
+import java.net.URI
+import java.nio.ByteBuffer
+import java.nio.file.Files
+import scala.meta.languageserver.ActiveJson
+import scala.meta.languageserver.MissingActiveJson
+import scala.meta.languageserver.SbtInitializeParams
+import scala.util.Try
+import com.typesafe.scalalogging.LazyLogging
+import io.circe.jawn.parseByteBuffer
+import monix.eval.Task
+import monix.execution.Cancelable
+import monix.execution.Scheduler
+import org.langmeta.io.AbsolutePath
+import org.langmeta.jsonrpc.BaseProtocolMessage
+import org.langmeta.jsonrpc.JsonRpcClient
+import org.langmeta.jsonrpc.Services
+import org.langmeta.lsp.LanguageClient
+import org.langmeta.lsp.LanguageServer
+import org.langmeta.lsp.TextDocument
+import org.langmeta.lsp.Window
+import sbt.internal.NGUnixDomainSocket
+
+class SbtServer(cwd: AbsolutePath, lspClient: JsonRpcClient)(
+    implicit scheduler: Scheduler
+) extends LazyLogging {
+  val forwardingServices: Services = Services.empty
+    .notification(Window.logMessage) { msg =>
+      lspClient.notify(Window.logMessage, msg)
+    }
+    .notification(TextDocument.publishDiagnostics) { msg =>
+      lspClient.notify(TextDocument.publishDiagnostics, msg)
+    }
+
+  private def fail(message: String) = Task.now(Left(message))
+  def connect: Task[Either[String, (JsonRpcClient, Cancelable)]] = {
+    Task(SbtServer.openSocketConnection(cwd)).flatMap {
+      case Left(err: MissingActiveJson) =>
+        fail(err.getMessage)
+      case Left(_: IOException) =>
+        fail(
+          s"Unable to establish connection with sbt server. " +
+            s"Do you have an active sbt 1.1.0 session?"
+        )
+      case Left(err) =>
+        val msg = s"Unexpected error opening connection to sbt server"
+        logger.error(msg, err)
+        fail(msg + ". Check .metaserver/metaserver.log")
+      case Right(socket) =>
+        implicit val client: LanguageClient =
+          new LanguageClient(socket.getOutputStream, logger)
+        val messages =
+          BaseProtocolMessage.fromInputStream(socket.getInputStream)
+        val server =
+          new LanguageServer(messages, client, forwardingServices, scheduler)
+        val stopServer = server.startTask.runAsync
+        val initialize = client.request(Sbt.initialize, SbtInitializeParams())
+        initialize.map { _ =>
+          Right(client -> stopServer)
+        }
+    }
+  }
+}
+
+object SbtServer extends LazyLogging {
+  def activeJson(cwd: AbsolutePath): AbsolutePath =
+    cwd.resolve("project").resolve("target").resolve("active.json")
+
+  def openSocketConnection(
+      cwd: AbsolutePath
+  ): Either[Throwable, NGUnixDomainSocket] = {
+    val active = activeJson(cwd)
+    for {
+      bytes <- {
+        if (Files.exists(active.toNIO)) Right(Files.readAllBytes(active.toNIO))
+        else Left(MissingActiveJson(active))
+      }
+      parsed <- parseByteBuffer(ByteBuffer.wrap(bytes))
+      activeJson <- parsed.as[ActiveJson]
+      uri <- Try(URI.create(activeJson.uri)).toEither
+      socket <- uri.getScheme match {
+        case "local" =>
+          logger.info(s"Connecting to sbt server socket ${uri.getPath}")
+          Try(new NGUnixDomainSocket(uri.getPath)).toEither
+        case invalid =>
+          Left(new IllegalArgumentException(s"Unsupported scheme $invalid"))
+      }
+    } yield socket
+  }
+}

--- a/metaserver/src/test/scala/tests/sbtserver/SbtServerTest.scala
+++ b/metaserver/src/test/scala/tests/sbtserver/SbtServerTest.scala
@@ -1,0 +1,70 @@
+package tests.sbtserver
+
+import java.nio.charset.StandardCharsets
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+import scala.meta.languageserver.sbtserver.Sbt
+import scala.meta.languageserver.sbtserver.SbtServer
+import scala.util.Failure
+import scala.util.Success
+import monix.eval.Task
+import monix.execution.Scheduler.Implicits.global
+import monix.reactive.Observable
+import org.langmeta.internal.io.PathIO
+import org.langmeta.io.AbsolutePath
+import org.langmeta.jsonrpc.Services
+import tests.MegaSuite
+
+case class SbtServerConnectionError(msg: String) extends Exception(msg)
+
+object SbtServerTest extends MegaSuite {
+  def openConnection(cwd: AbsolutePath): Task[SbtServer] = {
+    for {
+      process <- Task.defer {
+        val p = new ProcessBuilder("sbt")
+          .directory(cwd.toFile)
+          .start()
+        Observable
+          .fromInputStream(p.getInputStream)
+          .map[String](bytes => new String(bytes, StandardCharsets.UTF_8))
+          .doOnNext(print)
+          .findL(_.contains("sbt server"))
+          .map(_ => p)
+      }
+      sbt <- SbtServer.connect(cwd, Services.empty).map { response =>
+        println("Stopping sbt process..")
+        // NOTE(olafur) sbt still seems to keep on running despite this
+        process.getOutputStream.close()
+        process.getInputStream.close()
+        process.destroyForcibly()
+        response match {
+          case Left(err) => throw SbtServerConnectionError(err)
+          case Right(ok) =>
+            println("Established connection to sbt server.")
+            ok
+        }
+      }
+    } yield sbt
+  }
+
+  test("correct sbt 1.1 project establishes successful connection") {
+    val sbt1project =
+      PathIO.workingDirectory.resolve("..").resolve("test-workspace-sbt-1.1")
+    openConnection(sbt1project)
+    val program = for {
+      sbt <- openConnection(sbt1project)
+      response <- Sbt.setting.query("a/crossScalaVersions")(sbt.client)
+    } yield {
+      val Right(json) = response
+      val Right(crossScalaVersions) = json.value.as[List[String]]
+      assertEquals(crossScalaVersions, List("2.12.4"))
+      crossScalaVersions
+    }
+    val result = Await.result(program.materialize.runAsync, Duration(30, "s"))
+    result match {
+      case Success(_) => // hurrah :clap:
+      case Failure(err) => throw err
+    }
+  }
+
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.4
+sbt.version=1.1.0

--- a/test-workspace-sbt-1.1/a/src/main/scala/a/A.scala
+++ b/test-workspace-sbt-1.1/a/src/main/scala/a/A.scala
@@ -1,0 +1,8 @@
+package a
+
+object A extends App {
+  def foo: Int = {
+    ""
+  }
+
+}

--- a/test-workspace-sbt-1.1/build.sbt
+++ b/test-workspace-sbt-1.1/build.sbt
@@ -1,0 +1,4 @@
+lazy val a = project.settings(
+  // Global / serverLog / logLevel := Level.Debug,
+  scalaVersion := "2.12.4"
+)

--- a/test-workspace-sbt-1.1/project/build.properties
+++ b/test-workspace-sbt-1.1/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.1.0

--- a/tests/integration/src/test/scala/sbtserver/SbtServerTest.scala
+++ b/tests/integration/src/test/scala/sbtserver/SbtServerTest.scala
@@ -48,8 +48,7 @@ object SbtServerTest extends MegaSuite {
   }
 
   test("correct sbt 1.1 project establishes successful connection") {
-    val sbt1project =
-      PathIO.workingDirectory.resolve("..").resolve("test-workspace-sbt-1.1")
+    val sbt1project = PathIO.workingDirectory.resolve("test-workspace-sbt-1.1")
     openConnection(sbt1project)
     val program = for {
       sbt <- openConnection(sbt1project)
@@ -60,7 +59,7 @@ object SbtServerTest extends MegaSuite {
       assertEquals(crossScalaVersions, List("2.12.4"))
       crossScalaVersions
     }
-    val result = Await.result(program.materialize.runAsync, Duration(30, "s"))
+    val result = Await.result(program.materialize.runAsync, Duration(40, "s"))
     result match {
       case Success(_) => // hurrah :clap:
       case Failure(err) => throw err

--- a/tests/integration/src/test/scala/sbtserver/SbtServerTest.scala
+++ b/tests/integration/src/test/scala/sbtserver/SbtServerTest.scala
@@ -47,7 +47,10 @@ object SbtServerTest extends MegaSuite {
     } yield sbt
   }
 
-  test("correct sbt 1.1 project establishes successful connection") {
+  // NOTE(olafur): This test is failing on Travis but it works for me locally.
+  // I've disabled it in order to unblock the PR adding a note to re-enable
+  // this test in: https://github.com/scalameta/language-server/issues/176
+  ignore("correct sbt 1.1 project establishes successful connection") {
     val sbt1project = PathIO.workingDirectory.resolve("test-workspace-sbt-1.1")
     openConnection(sbt1project)
     val program = for {

--- a/tests/integration/src/test/scala/sbtserver/SbtServerTest.scala
+++ b/tests/integration/src/test/scala/sbtserver/SbtServerTest.scala
@@ -6,10 +6,8 @@ import scala.meta.languageserver.sbtserver.Sbt
 import scala.meta.languageserver.sbtserver.SbtServer
 import scala.util.Failure
 import scala.util.Success
-import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.langmeta.internal.io.PathIO
-import org.langmeta.io.AbsolutePath
 import org.langmeta.jsonrpc.Services
 import org.langmeta.lsp.TextDocument
 import org.langmeta.lsp.Window

--- a/tests/integration/src/test/scala/sbtserver/SbtServerTest.scala
+++ b/tests/integration/src/test/scala/sbtserver/SbtServerTest.scala
@@ -1,6 +1,5 @@
 package tests.sbtserver
 
-import java.nio.charset.StandardCharsets
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import scala.meta.languageserver.sbtserver.Sbt
@@ -9,60 +8,37 @@ import scala.util.Failure
 import scala.util.Success
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
-import monix.reactive.Observable
 import org.langmeta.internal.io.PathIO
 import org.langmeta.io.AbsolutePath
 import org.langmeta.jsonrpc.Services
+import org.langmeta.lsp.TextDocument
+import org.langmeta.lsp.Window
 import tests.MegaSuite
 
 case class SbtServerConnectionError(msg: String) extends Exception(msg)
 
 object SbtServerTest extends MegaSuite {
-  def openConnection(cwd: AbsolutePath): Task[SbtServer] = {
-    for {
-      process <- Task.defer {
-        val p = new ProcessBuilder("sbt")
-          .directory(cwd.toFile)
-          .start()
-        Observable
-          .fromInputStream(p.getInputStream)
-          .map[String](bytes => new String(bytes, StandardCharsets.UTF_8))
-          .doOnNext(print)
-          .findL(_.contains("sbt server"))
-          .map(_ => p)
-      }
-      sbt <- SbtServer.connect(cwd, Services.empty).map { response =>
-        println("Stopping sbt process..")
-        // NOTE(olafur) sbt still seems to keep on running despite this
-        process.getOutputStream.close()
-        process.getInputStream.close()
-        process.destroyForcibly()
-        response match {
-          case Left(err) => throw SbtServerConnectionError(err)
-          case Right(ok) =>
-            println("Established connection to sbt server.")
-            ok
-        }
-      }
-    } yield sbt
-  }
 
-  // NOTE(olafur): This test is failing on Travis but it works for me locally.
-  // I've disabled it in order to unblock the PR adding a note to re-enable
-  // this test in: https://github.com/scalameta/language-server/issues/176
-  ignore("correct sbt 1.1 project establishes successful connection") {
-    val sbt1project = PathIO.workingDirectory.resolve("test-workspace-sbt-1.1")
-    openConnection(sbt1project)
+  test("correct sbt 1.1 project establishes successful connection") {
+    val services = Services.empty
+      .notification(Window.logMessage)(msg => ())
+      .notification(TextDocument.publishDiagnostics)(msg => ())
     val program = for {
-      sbt <- openConnection(sbt1project)
-      response <- Sbt.setting.query("a/crossScalaVersions")(sbt.client)
+      sbt <- SbtServer.connect(PathIO.workingDirectory, services).map {
+        case Left(err) => throw SbtServerConnectionError(err)
+        case Right(ok) =>
+          println("Established connection to sbt server.")
+          ok
+      }
+      response <- Sbt.setting.query("metaserver/crossScalaVersions")(sbt.client)
     } yield {
       val Right(json) = response
       val Right(crossScalaVersions) = json.value.as[List[String]]
+      sbt.runningServer.cancel()
       assertEquals(crossScalaVersions, List("2.12.4"))
       crossScalaVersions
     }
-    val result = Await.result(program.materialize.runAsync, Duration(40, "s"))
+    val result = Await.result(program.materialize.runAsync, Duration(5, "s"))
     result match {
       case Success(_) => // hurrah :clap:
       case Failure(err) => throw err

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -13,10 +13,21 @@
     "configuration": {
       "title": "Scalameta Language Server",
       "properties": {
+        "scalameta.sbt.enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "EXPERIMENTAL. Use sbt language server to compile on file save and report squgglies. Requires sbt 1.1.0"
+        },
+        "scalameta.sbt.command": {
+          "type": "string",
+          "default": "test:compile",
+          "description": "Which sbt command to run on file save."
+        },
         "scalameta.scalac.enabled": {
           "type": "boolean",
           "default": false,
-          "description": "EXPERIMENTAL. Enable squigglies and completions as you type with the Scala Presentation Compiler."
+          "description":
+            "EXPERIMENTAL. Enable squigglies and completions as you type with the Scala Presentation Compiler."
         },
         "scalameta.scalafmt.enabled": {
           "type": "boolean",
@@ -26,7 +37,8 @@
         "scalameta.scalafmt.version": {
           "type": "string",
           "default": "1.3.0",
-          "description": "Version of scalafmt to use, default to latest stable release."
+          "description":
+            "Version of scalafmt to use, default to latest stable release."
         },
         "scalameta.scalafmt.confPath": {
           "type": "string",
@@ -77,6 +89,11 @@
         "command": "scalameta.clearIndexCache",
         "category": "Scalameta Language Server",
         "title": "Clear index cache"
+      },
+      {
+        "command": "scalameta.sbtConnect",
+        "category": "Scalameta Language Server",
+        "title": "Connect to sbt server"
       },
       {
         "command": "scalameta.resetPresentationCompiler",

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -105,9 +105,18 @@ export async function activate(context: ExtensionContext) {
         });
       }
     );
+    const sbtConnectCommand = commands.registerCommand(
+      "scalameta.sbtConnect",
+      async () => {
+        return client.sendRequest(ExecuteCommandRequest.type, {
+          command: "sbtConnect"
+        });
+      }
+    );
     context.subscriptions.push(
       clearIndexCacheCommand,
-      resetPresentationCompiler
+      resetPresentationCompiler,
+      sbtConnectCommand
     );
   });
 


### PR DESCRIPTION
Fixes #169. 

![2018-01-07 23 39 52](https://user-images.githubusercontent.com/1408093/34655026-2432bcce-f404-11e7-8d9f-a7b8b260d4af.gif)

This PR adds an integration to connect to sbt 1.1 language server
to compile via sbt on file save and publish error messages as
diagnostics. We reuse the LanguageServer and LanguageClient
utilities but we are now a client instead of server, compared to when
connecting to editors.

This PR adds a new SbtConnect command to re-estabilish a connection
with sbt in case of a disconnection, for example if you exit sbt and
open again. Ideally, we can figure this out automatically in the future,
but a manual approach is a good start.

There are two new settings to control this new feature

- sbt.enabled, must be true to use this feature, false by default.
- sbt.command, which command to execute on file save. This makes it
  possible to for example run or test instead of compile or select
  a subproject in a multi module build.

I did not upgrade the build to sbt 1.1 because intellij import doesn't
work with sbt 1.1 yet for some reason. Instead, I added a new subproject `test-workspace-sbt-1.1` to play around with this new feature.

There are no integration tests yet since this is quite hard to test. I hope that we add tests once https://github.com/sbt/ipcsocket is published.
  
  