### PR TITLE
Make it possible to inject custom logger to jsonrpc/lsp.

### DIFF
--- a/jsonrpc/src/main/scala/org/langmeta/jsonrpc/BaseProtocolMessage.scala
+++ b/jsonrpc/src/main/scala/org/langmeta/jsonrpc/BaseProtocolMessage.scala
@@ -2,6 +2,8 @@ package org.langmeta.jsonrpc
 
 import java.io.InputStream
 import java.util.concurrent.Executors
+import com.typesafe.scalalogging.LazyLogging
+import com.typesafe.scalalogging.Logger
 import monix.execution.ExecutionModel
 import monix.execution.Scheduler
 import monix.reactive.Observable
@@ -19,8 +21,13 @@ case class BaseProtocolMessage(header: Map[String, String], content: String) {
   }
 }
 
-object BaseProtocolMessage {
+object BaseProtocolMessage extends LazyLogging {
   def fromInputStream(in: InputStream): Observable[BaseProtocolMessage] =
+    fromInputStream(in, logger)
+  def fromInputStream(
+      in: InputStream,
+      logger: Logger
+  ): Observable[BaseProtocolMessage] =
     Observable
       .fromInputStream(in)
       .executeOn(
@@ -29,5 +36,5 @@ object BaseProtocolMessage {
           ExecutionModel.AlwaysAsyncExecution
         )
       )
-      .liftByOperator(new BaseProtocolMessageParser)
+      .liftByOperator(new BaseProtocolMessageParser(logger))
 }

--- a/jsonrpc/src/main/scala/org/langmeta/jsonrpc/BaseProtocolMessageParser.scala
+++ b/jsonrpc/src/main/scala/org/langmeta/jsonrpc/BaseProtocolMessageParser.scala
@@ -3,15 +3,14 @@ package org.langmeta.jsonrpc
 import java.nio.charset.StandardCharsets
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.Future
-import com.typesafe.scalalogging.LazyLogging
+import com.typesafe.scalalogging.Logger
 import monix.execution.Ack
 import monix.execution.Scheduler
 import monix.reactive.observables.ObservableLike.Operator
 import monix.reactive.observers.Subscriber
 
-final class BaseProtocolMessageParser
-    extends Operator[Array[Byte], BaseProtocolMessage]
-    with LazyLogging {
+final class BaseProtocolMessageParser(logger: Logger)
+    extends Operator[Array[Byte], BaseProtocolMessage] {
   override def apply(
       out: Subscriber[BaseProtocolMessage]
   ): Subscriber[Array[Byte]] = {

--- a/jsonrpc/src/main/scala/org/langmeta/jsonrpc/MessageWriter.scala
+++ b/jsonrpc/src/main/scala/org/langmeta/jsonrpc/MessageWriter.scala
@@ -2,7 +2,7 @@ package org.langmeta.jsonrpc
 
 import java.io.OutputStream
 import java.nio.charset.StandardCharsets
-import com.typesafe.scalalogging.LazyLogging
+import com.typesafe.scalalogging.Logger
 import io.circe.Encoder
 import io.circe.syntax._
 
@@ -20,7 +20,7 @@ import io.circe.syntax._
  *
  * @note The header part is defined to be ASCII encoded, while the content part is UTF8.
  */
-class MessageWriter(out: OutputStream) extends LazyLogging {
+class MessageWriter(out: OutputStream, logger: Logger) {
   private val ContentLen = "Content-Length"
 
   /** Lock protecting the output stream, so multiple writes don't mix message chunks. */

--- a/jsonrpc/src/main/scala/org/langmeta/jsonrpc/Services.scala
+++ b/jsonrpc/src/main/scala/org/langmeta/jsonrpc/Services.scala
@@ -1,11 +1,12 @@
 package org.langmeta.jsonrpc
 
 import com.typesafe.scalalogging.LazyLogging
-import monix.eval.Task
+import com.typesafe.scalalogging.Logger
 import io.circe.Decoder
 import io.circe.Encoder
 import io.circe.Json
 import io.circe.syntax._
+import monix.eval.Task
 
 trait Service[A, B] {
   def handle(request: A): Task[B]
@@ -45,6 +46,10 @@ object Service extends LazyLogging {
   }
 
   def notification[A: Decoder](method: String)(
+      f: Service[A, Unit]
+  ): NamedJsonRpcService = notification[A](method, logger)(f)
+
+  def notification[A: Decoder](method: String, logger: Logger)(
       f: Service[A, Unit]
   ): NamedJsonRpcService =
     new NamedJsonRpcService {

--- a/lsp4s/src/main/scala/org/langmeta/lsp/LanguageClient.scala
+++ b/lsp4s/src/main/scala/org/langmeta/lsp/LanguageClient.scala
@@ -4,7 +4,7 @@ import java.io.OutputStream
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.duration.Duration
 import cats.syntax.either._
-import com.typesafe.scalalogging.LazyLogging
+import com.typesafe.scalalogging.Logger
 import io.circe.Decoder
 import io.circe.Encoder
 import io.circe.syntax._
@@ -20,8 +20,8 @@ import org.langmeta.jsonrpc.Request
 import org.langmeta.jsonrpc.RequestId
 import org.langmeta.jsonrpc.Response
 
-class LanguageClient(out: OutputStream) extends LazyLogging with JsonRpcClient {
-  private val writer = new MessageWriter(out)
+class LanguageClient(out: OutputStream, logger: Logger) extends JsonRpcClient {
+  private val writer = new MessageWriter(out, logger)
   private val counter: AtomicInt = Atomic(1)
   private val activeServerRequests =
     TrieMap.empty[RequestId, Callback[Response]]

--- a/lsp4s/src/main/scala/org/langmeta/lsp/LanguageServer.scala
+++ b/lsp4s/src/main/scala/org/langmeta/lsp/LanguageServer.scala
@@ -4,7 +4,7 @@ import scala.collection.concurrent.TrieMap
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import scala.util.control.NonFatal
-import com.typesafe.scalalogging.LazyLogging
+import com.typesafe.scalalogging.Logger
 import io.circe.Json
 import io.circe.parser.parse
 import io.circe.syntax._
@@ -18,8 +18,9 @@ final class LanguageServer(
     in: Observable[BaseProtocolMessage],
     client: LanguageClient,
     services: Services,
-    requestScheduler: Scheduler
-) extends LazyLogging {
+    requestScheduler: Scheduler,
+    logger: Logger
+) {
   private val activeClientRequests: TrieMap[Json, Cancelable] = TrieMap.empty
   private val cancelNotification =
     Service.notification[CancelParams]("$/cancelRequest") { params =>

--- a/metaserver/src/main/scala/scala/meta/languageserver/Main.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Main.scala
@@ -34,13 +34,14 @@ object Main extends LazyLogging {
       System.setErr(err)
       logger.info(s"Starting server in $cwd")
       logger.info(s"Classpath: ${Properties.javaClassPath}")
-      val client = new LanguageClient(stdout)
+      val client = new LanguageClient(stdout, logger)
       val services = new ScalametaServices(cwd, client, s)
       val languageServer = new LanguageServer(
         BaseProtocolMessage.fromInputStream(stdin),
         client,
         services.services,
-        s
+        s,
+        logger
       )
       languageServer.listen()
     } catch {

--- a/metaserver/src/test/scala/tests/search/SymbolIndexTest.scala
+++ b/metaserver/src/test/scala/tests/search/SymbolIndexTest.scala
@@ -17,6 +17,7 @@ import scala.meta.languageserver.search.InMemorySymbolIndex
 import scala.meta.languageserver.search.InverseSymbolIndexer
 import scala.meta.languageserver.search.SymbolIndex
 import scala.{meta => m}
+import com.typesafe.scalalogging.LazyLogging
 import monix.execution.schedulers.TestScheduler
 import org.langmeta.io.AbsolutePath
 import org.langmeta.io.Classpath
@@ -25,7 +26,7 @@ import org.langmeta.semanticdb.Symbol
 import tests.MegaSuite
 import utest._
 
-object SymbolIndexTest extends MegaSuite {
+object SymbolIndexTest extends MegaSuite with LazyLogging {
   implicit val cwd: AbsolutePath =
     AbsolutePath(BuildInfo.testWorkspaceBaseDirectory)
   object path {
@@ -57,7 +58,7 @@ object SymbolIndexTest extends MegaSuite {
   val s = TestScheduler()
   val stdout = new PipedOutputStream()
   // TODO(olafur) run this as part of utest.runner.Framework.setup()
-  val client = new LanguageClient(stdout)
+  val client = new LanguageClient(stdout, logger)
   val metaserver = new ScalametaServices(cwd, client, s)
   metaserver
     .initialize(InitializeParams(0L, cwd.toString(), ClientCapabilities()))


### PR DESCRIPTION
I'm experimenting with Jorge with a bloop integration and we are trying
to share some code. In Bloop they have their own custom logging
infrastructure so this commit makes it possible to inject custom
loggers into the core jsonrpc classes.