### PR TITLE
Replace withObject with mapObject

### DIFF
--- a/jsonrpc/src/main/scala/org/langmeta/jsonrpc/MessageWriter.scala
+++ b/jsonrpc/src/main/scala/org/langmeta/jsonrpc/MessageWriter.scala
@@ -34,7 +34,7 @@ class MessageWriter(out: OutputStream, logger: Logger) {
     lock.synchronized {
       require(h.get(ContentLen).isEmpty)
 
-      val json = msg.asJson.withObject(_.add("jsonrpc", "2.0".asJson).asJson)
+      val json = msg.asJson.mapObject(_.add("jsonrpc", "2.0".asJson))
       val str = json.noSpaces
       val contentBytes = str.getBytes(StandardCharsets.UTF_8)
       val headers = (h + (ContentLen -> contentBytes.length))


### PR DESCRIPTION
Basically `withObject` is `flatMap` and `mapObject` is `map`.

They both resolve to an identity function in case the `Json` is not a `JObject`.